### PR TITLE
fix(arxiv-doc-builder): normalize arXiv ID before API query

### DIFF
--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -9,6 +9,7 @@ import argparse
 import re
 import subprocess
 import sys
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -33,7 +34,7 @@ def normalize_arxiv_id(arxiv_id: str) -> str:
 def fetch_title_from_arxiv(arxiv_id: str) -> Optional[str]:
     """Fetch title from arXiv API."""
     arxiv_id = normalize_arxiv_id(arxiv_id)
-    url = f"https://export.arxiv.org/api/query?id_list={arxiv_id}"
+    url = "https://export.arxiv.org/api/query?" + urllib.parse.urlencode({"id_list": arxiv_id})
     try:
         with urllib.request.urlopen(url, timeout=10) as resp:
             tree = ET.parse(resp)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -15,8 +15,24 @@ from pathlib import Path
 from typing import Optional
 
 
+def normalize_arxiv_id(arxiv_id: str) -> str:
+    """Normalize arXiv ID by zero-padding the numeric part.
+
+    arXiv new-style IDs use YYMM.NNNNN (5 digits) from 1501 onwards,
+    and YYMM.NNNN (4 digits) for 0704-1412. The arXiv website redirects
+    short IDs but the API requires exact format.
+    """
+    m = re.match(r"^(\d{4})\.(\d+)$", arxiv_id)
+    if not m:
+        return arxiv_id  # old-style (e.g. math/0703001) or already correct
+    yymm, num = m.group(1), m.group(2)
+    width = 5 if int(yymm) >= 1501 else 4
+    return f"{yymm}.{num.zfill(width)}"
+
+
 def fetch_title_from_arxiv(arxiv_id: str) -> Optional[str]:
     """Fetch title from arXiv API."""
+    arxiv_id = normalize_arxiv_id(arxiv_id)
     url = f"http://export.arxiv.org/api/query?id_list={arxiv_id}"
     try:
         with urllib.request.urlopen(url, timeout=10) as resp:

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -22,18 +22,18 @@ def normalize_arxiv_id(arxiv_id: str) -> str:
     and YYMM.NNNN (4 digits) for 0704-1412. The arXiv website redirects
     short IDs but the API requires exact format.
     """
-    m = re.match(r"^(\d{4})\.(\d+)$", arxiv_id)
+    m = re.match(r"^(\d{4})\.(\d+)(v\d+)?$", arxiv_id)
     if not m:
         return arxiv_id  # old-style (e.g. math/0703001) or already correct
-    yymm, num = m.group(1), m.group(2)
+    yymm, num, version = m.group(1), m.group(2), m.group(3) or ""
     width = 5 if int(yymm) >= 1501 else 4
-    return f"{yymm}.{num.zfill(width)}"
+    return f"{yymm}.{num.zfill(width)}{version}"
 
 
 def fetch_title_from_arxiv(arxiv_id: str) -> Optional[str]:
     """Fetch title from arXiv API."""
     arxiv_id = normalize_arxiv_id(arxiv_id)
-    url = f"http://export.arxiv.org/api/query?id_list={arxiv_id}"
+    url = f"https://export.arxiv.org/api/query?id_list={arxiv_id}"
     try:
         with urllib.request.urlopen(url, timeout=10) as resp:
             tree = ET.parse(resp)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_normalize_arxiv_id.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_normalize_arxiv_id.py
@@ -1,0 +1,52 @@
+"""Contract tests for arXiv ID normalization.
+
+Contract: all valid representations of the same arXiv paper must
+normalize to the canonical zero-padded form accepted by the Atom API.
+"""
+
+import pytest
+
+from arxiv_doc_builder.convert_latex import normalize_arxiv_id
+
+
+# New-style IDs (YYMM >= 1501): must be 5 digits after the dot
+@pytest.mark.parametrize(
+    "input_id, expected",
+    [
+        ("2506.1376", "2506.01376"),       # short → padded
+        ("2506.01376", "2506.01376"),       # already canonical
+        ("1501.1", "1501.00001"),           # boundary month, minimal digits
+        ("1501.00001", "1501.00001"),       # boundary month, already canonical
+        ("2506.1376v2", "2506.01376v2"),    # short with version suffix
+        ("2506.01376v1", "2506.01376v1"),   # canonical with version suffix
+    ],
+)
+def test_new_style_ids_padded_to_5_digits(input_id, expected):
+    assert normalize_arxiv_id(input_id) == expected
+
+
+# Old new-style IDs (0704 <= YYMM <= 1412): must be 4 digits after the dot
+@pytest.mark.parametrize(
+    "input_id, expected",
+    [
+        ("0704.1", "0704.0001"),           # short → padded
+        ("0704.0001", "0704.0001"),        # already canonical
+        ("1412.7890", "1412.7890"),        # last 4-digit month, already canonical
+        ("1412.789v3", "1412.0789v3"),     # with version suffix
+    ],
+)
+def test_old_new_style_ids_padded_to_4_digits(input_id, expected):
+    assert normalize_arxiv_id(input_id) == expected
+
+
+# Legacy IDs (subject-class/YYMMNNN): passed through unchanged
+@pytest.mark.parametrize(
+    "input_id",
+    [
+        "math/0703001",
+        "hep-th/9901001",
+        "cond-mat/0601234",
+    ],
+)
+def test_legacy_ids_unchanged(input_id):
+    assert normalize_arxiv_id(input_id) == input_id


### PR DESCRIPTION
## Summary
- The arXiv website redirects short IDs (e.g. 2506.1376 -> 2506.01376) but the Atom API requires exact zero-padded format, causing "Unknown Title" for short IDs
- Add `normalize_arxiv_id()` that pads to 5 digits for YYMM >= 1501 and 4 digits for 0704-1412 before querying the API
- Old-style IDs (e.g. math/0703001) are passed through unchanged

## Test plan
- [ ] Short ID like `2506.1376` returns correct title from API
- [ ] Canonical ID like `2506.01376` is not modified
- [ ] Old 4-digit format ID like `0704.0001` is handled correctly
- [ ] Old-style ID like `math/0703001` passes through unchanged