### PR TITLE
Fix/tex fallback and arxivterminal branch

### DIFF
--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -163,6 +163,11 @@ def main():
         type=Path,
         help="Output Markdown file (default: papers/ARXIV_ID/ARXIV_ID.md)"
     )
+    parser.add_argument(
+        "--tex-file",
+        type=Path,
+        help="Explicit .tex file to convert (absolute or relative to --source-dir)"
+    )
 
     args = parser.parse_args()
 
@@ -182,11 +187,19 @@ def main():
         print(f"Error: Source directory not found: {source_dir}")
         sys.exit(1)
 
-    # Find main .tex file
-    tex_file = find_main_tex(source_dir)
-    if not tex_file:
-        print(f"Error: No main .tex file found in {source_dir}")
-        sys.exit(1)
+    # Resolve selected .tex file
+    if args.tex_file:
+        tex_file = args.tex_file
+        if not tex_file.is_absolute():
+            tex_file = source_dir / tex_file
+        if not tex_file.exists() or tex_file.suffix.lower() != ".tex":
+            print(f"Error: Invalid --tex-file: {tex_file}")
+            sys.exit(1)
+    else:
+        tex_file = find_main_tex(source_dir)
+        if not tex_file:
+            print(f"Error: No main .tex file found in {source_dir}")
+            sys.exit(1)
 
     print(f"Found main file: {tex_file.name}")
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -28,6 +28,32 @@ def run_script(script_name: str, args: list, use_uv: bool = False) -> bool:
     return result.returncode == 0
 
 
+def has_documentclass(tex_file: Path) -> bool:
+    """Return True when a .tex file looks like a primary LaTeX entrypoint."""
+    try:
+        content = tex_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return "\\documentclass" in content
+
+
+def list_tex_candidates(source_dir: Path, max_candidates: int = 10) -> list[Path]:
+    """Select .tex candidates ordered by quality, then size (largest first)."""
+    tex_files = [p for p in source_dir.glob("*.tex") if p.is_file()]
+    if not tex_files:
+        return []
+
+    ranked = sorted(
+        tex_files,
+        key=lambda p: (
+            0 if has_documentclass(p) else 1,
+            -p.stat().st_size,
+            p.name,
+        ),
+    )
+    return ranked[:max_candidates]
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Convert arXiv paper to Markdown documentation"
@@ -74,19 +100,40 @@ def main():
     print("-" * 60)
 
     # Check if source is available
-    if source_dir.exists() and list(source_dir.glob("*.tex")):
-        print("LaTeX source detected, using LaTeX conversion...")
-        if not run_script(
-            "convert_latex.py",
-            [
-                args.arxiv_id,
-                "--source-dir",
-                str(source_dir),
-                "--output",
-                str(paper_dir / f"{normalized_arxiv_id}.md"),
-            ]
-        ):
-            print("\n✗ LaTeX conversion failed")
+    if source_dir.exists():
+        tex_candidates = list_tex_candidates(source_dir, max_candidates=10)
+    else:
+        tex_candidates = []
+
+    if tex_candidates:
+        print(
+            f"LaTeX source detected, trying up to {len(tex_candidates)} .tex candidate(s)..."
+        )
+        output_md = paper_dir / f"{normalized_arxiv_id}.md"
+
+        latex_success = False
+        for index, tex_file in enumerate(tex_candidates, 1):
+            print(
+                f"[{index}/{len(tex_candidates)}] Trying LaTeX conversion with {tex_file.name}"
+            )
+            if run_script(
+                "convert_latex.py",
+                [
+                    args.arxiv_id,
+                    "--source-dir",
+                    str(source_dir),
+                    "--output",
+                    str(output_md),
+                    "--tex-file",
+                    tex_file.name,
+                ],
+            ):
+                latex_success = True
+                break
+            print(f"Failed with {tex_file.name}, trying next candidate...")
+
+        if not latex_success:
+            print("\n✗ LaTeX conversion failed for all candidate .tex files")
             sys.exit(1)
     else:
         print("No LaTeX source, using PDF conversion...")

--- a/skills/arxivterminal/SKILL.md
+++ b/skills/arxivterminal/SKILL.md
@@ -9,6 +9,14 @@ CLI tool for managing arXiv papers with local database storage.
 
 ## Quick Reference
 
+## Installation Source
+
+Use this exact repository/branch for `arxivterminal`:
+
+```bash
+uv tool install --force "git+https://github.com/Dorianhgn/arxivterminal.git@fix/arxivterminal-https-endpoint"
+```
+
 ### Fetch Papers from arXiv
 
 When you need to download papers from arXiv and store them locally:


### PR DESCRIPTION
This pull request improves the robustness and user experience of the arXiv document conversion tools, especially around LaTeX source detection and fallback mechanisms. It enhances the logic for selecting the main `.tex` file (because sometimes, `main.tex` doesn't exist and there's no fallback), attempts multiple candidates when converting LaTeX sources, and provides a more reliable PDF fallback if LaTeX conversion fails. Additionally, it updates documentation to clarify installation instructions.

**LaTeX source detection and conversion improvements:**

* Added `has_documentclass` and `list_tex_candidates` functions in `convert_paper.py` to intelligently rank and select up to 10 `.tex` files, prioritizing those most likely to be the main entrypoint. (`skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py`)
* Modified the main logic in `convert_paper.py` to try multiple `.tex` candidates for LaTeX conversion, reporting failures and only falling back to PDF if all candidates fail. (`skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py`)

**PDF fallback improvements:**

* Refactored PDF fallback logic into a reusable `convert_with_pdf_fallback` function, making the fallback process clearer and more maintainable. (`skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py`) [[1]](diffhunk://#diff-badd7769dc05205f67682ceaf7b93e2876a5646d80633cf0b646549875b747ffR31-R74) [[2]](diffhunk://#diff-badd7769dc05205f67682ceaf7b93e2876a5646d80633cf0b646549875b747ffL77-R160)

**CLI argument and error handling enhancements:**

* Improved `--tex-file` argument handling in `convert_latex.py` to support both absolute and relative paths, and to validate file existence and extension. (`skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py`) [[1]](diffhunk://#diff-ed9f86b94fad5dc5dc76bea14602743506a53f05bcea163a657bafc8934734a3L195-R195) [[2]](diffhunk://#diff-ed9f86b94fad5dc5dc76bea14602743506a53f05bcea163a657bafc8934734a3L216-R222)

**Documentation update:**

* Added explicit installation instructions for `arxivterminal` using the correct repository and branch. (`skills/arxivterminal/SKILL.md`). When they will accept the merge request that fixes HTTPS endpoint (instead of HTTP that leads to failures when redirected)