### PR TITLE
feat(arxiv-doc-builder): fail-first on ambiguous main .tex selection

### DIFF
--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -137,20 +137,28 @@ See [references/pdf-conversion.md](references/pdf-conversion.md) for details on 
 
 ## Troubleshooting: Multiple \documentclass Files
 
-Some arXiv papers (e.g., PRL with supplemental material) contain multiple `.tex` files, each with its own `\documentclass`. When this happens, the converter warns:
+Some arXiv papers (e.g., PRL with supplemental material) contain multiple `.tex` files, each with its own `\documentclass`. Automatic selection is unreliable in this case — the canonical example is `1911.04882`, which ships both the main PRL paper and an independent PRL supplement, and either can convert successfully. Since pandoc succeeding is not evidence that the selected file is the correct entry point, `convert-paper` refuses to guess: it fails explicitly with **exit code 2** and lists all candidates.
+
+Example failure output:
 
 ```
-⚠ Found 2 files with \documentclass:
-  [0] main_paper.tex
-  [1] supplemental_material.tex
-  Non-interactive mode, selecting [0] main_paper.tex
+Error: Found 2 files with \documentclass in /path/to/1911.04882/source:
+  - /path/to/1911.04882/source/main_paper.tex
+  - /path/to/1911.04882/source/supplemental_material.tex
+
+Main .tex selection is ambiguous. Re-run with --tex-file pointing at the correct file, e.g.:
+  convert-paper <ARXIV_ID> --skip-fetch --tex-file /path/to/1911.04882/source/main_paper.tex
+
+If you originally passed --output-dir, include the same value in the re-run.
 ```
 
-If the wrong file was selected, re-run the LaTeX converter directly with `--tex-file`:
+To resolve, re-run `convert-paper` with `--tex-file` pointing at the correct main file, combined with `--skip-fetch` to reuse the already-downloaded source:
 
 ```bash
-convert_latex.py ARXIV_ID --source-dir {output-dir}/{ARXIV_ID}/source --tex-file {output-dir}/{ARXIV_ID}/source/correct_file.tex --output {output-dir}/{ARXIV_ID}/{ARXIV_ID}.md
+convert-paper 1911.04882 --skip-fetch --tex-file /path/to/1911.04882/source/main_paper.tex
 ```
+
+If the original run used `--output-dir`, pass the same value again so that `convert-paper` reconstructs the correct paper directory.
 
 ## Troubleshooting: pandoc Conversion Failures
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -47,9 +47,30 @@ def fetch_title_from_arxiv(arxiv_id: str) -> Optional[str]:
     return None
 
 
+class AmbiguousMainTexError(Exception):
+    """Raised when multiple \\documentclass files exist and no explicit --tex-file was given.
+
+    Selecting the correct entry point cannot be done reliably by heuristics
+    (file size, sort order, or trial conversion) because supplements and
+    fragments can convert successfully just like the main paper. The caller
+    must re-run with --tex-file pointing at the intended file.
+    """
+
+    def __init__(self, candidates: list):
+        self.candidates = candidates
+        super().__init__(f"Found {len(candidates)} files with \\documentclass")
+
+
 def find_main_tex(source_dir: Path) -> Optional[Path]:
-    """Find the main .tex file in source directory."""
-    # Common main file names
+    """Find the main .tex file in source directory.
+
+    Raises AmbiguousMainTexError if multiple files with \\documentclass are
+    present and none of the conventional names (main.tex, paper.tex, ms.tex,
+    article.tex) exists. The caller is expected to translate this into a
+    fail-first error and require --tex-file on the re-run.
+    """
+    # Conventional main file names take precedence over the ambiguity check:
+    # if the source already uses a known layout, there is nothing ambiguous.
     candidates = ["main.tex", "paper.tex", "ms.tex", "article.tex"]
 
     for candidate in candidates:
@@ -68,26 +89,7 @@ def find_main_tex(source_dir: Path) -> Optional[Path]:
         return doc_files[0]
 
     if len(doc_files) > 1:
-        # Multiple \documentclass files found — prompt user to select
-        print(f"\n⚠ Found {len(doc_files)} files with \\documentclass:")
-        for i, f in enumerate(doc_files):
-            print(f"  [{i}] {f.name}")
-
-        if sys.stdin.isatty():
-            while True:
-                try:
-                    choice = input(f"Select main file [0-{len(doc_files)-1}]: ").strip()
-                    idx = int(choice)
-                    if 0 <= idx < len(doc_files):
-                        return doc_files[idx]
-                    print(f"  Invalid index. Enter 0-{len(doc_files)-1}.")
-                except (ValueError, EOFError):
-                    print(f"  Defaulting to [{0}] {doc_files[0].name}")
-                    return doc_files[0]
-        else:
-            # Non-interactive: pick first and warn
-            print(f"  Non-interactive mode, selecting [{0}] {doc_files[0].name}")
-            return doc_files[0]
+        raise AmbiguousMainTexError(doc_files)
 
     return None
 
@@ -237,7 +239,35 @@ def main():
             print(f"Error: Specified .tex file not found: {tex_file}")
             sys.exit(1)
     else:
-        tex_file = find_main_tex(source_dir)
+        try:
+            tex_file = find_main_tex(source_dir)
+        except AmbiguousMainTexError as e:
+            # Fail-first: do not guess. Require an explicit --tex-file on re-run.
+            # Use absolute paths so the suggestion is portable across cwd and
+            # --output-dir differences between the original run and the re-run.
+            abs_candidates = [c.resolve() for c in e.candidates]
+            print(
+                f"Error: Found {len(abs_candidates)} files with \\documentclass "
+                f"in {source_dir.resolve()}:",
+                file=sys.stderr,
+            )
+            for c in abs_candidates:
+                print(f"  - {c}", file=sys.stderr)
+            print(
+                "\nMain .tex selection is ambiguous. Re-run with --tex-file "
+                "pointing at the correct file, e.g.:",
+                file=sys.stderr,
+            )
+            print(
+                f"  convert-paper <ARXIV_ID> --skip-fetch --tex-file {abs_candidates[0]}",
+                file=sys.stderr,
+            )
+            print(
+                "\nIf you originally passed --output-dir, include the same value "
+                "in the re-run.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
     if not tex_file:
         print(f"Error: No main .tex file found in {source_dir}")
         sys.exit(1)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -177,7 +177,15 @@ conversion_date: "{datetime.now().isoformat()}"
 
 
 def copy_figures(source_dir: Path, output_dir: Path):
-    """Copy figure files to output directory."""
+    """Copy figure files to output directory.
+
+    Recurses into source_dir because LaTeX papers commonly place figures
+    below the entrypoint (source/subdir/fig.png) or above it
+    (source/fig.png referenced via ../fig.png). The markdown post-processor
+    already flattens image paths to figures/<basename>, so copying by
+    basename matches the rewritten references regardless of where in the
+    source tree the file originated.
+    """
     figures_dir = output_dir / "figures"
     figures_dir.mkdir(exist_ok=True)
 
@@ -186,7 +194,7 @@ def copy_figures(source_dir: Path, output_dir: Path):
 
     copied = 0
     for ext in image_exts:
-        for img_file in source_dir.glob(f"*{ext}"):
+        for img_file in source_dir.rglob(f"*{ext}"):
             dest = figures_dir / img_file.name
             dest.write_bytes(img_file.read_bytes())
             copied += 1

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -179,12 +179,13 @@ conversion_date: "{datetime.now().isoformat()}"
 def copy_figures(source_dir: Path, output_dir: Path):
     """Copy figure files to output directory.
 
-    Recurses into source_dir because LaTeX papers commonly place figures
-    below the entrypoint (source/subdir/fig.png) or above it
-    (source/fig.png referenced via ../fig.png). The markdown post-processor
-    already flattens image paths to figures/<basename>, so copying by
-    basename matches the rewritten references regardless of where in the
-    source tree the file originated.
+    Only top-level figures are copied. Recursing is tempting but unsafe:
+    the markdown post-processor rewrites all image references to
+    ``figures/<basename>``, so two nested assets with the same basename
+    (e.g. ``main/fig1.png`` and ``supp/fig1.png``) would silently collide
+    and substitute the wrong asset for at least one reference. A proper
+    fix requires collision-aware, path-preserving copying plus a smarter
+    rewriter, which is out of scope here.
     """
     figures_dir = output_dir / "figures"
     figures_dir.mkdir(exist_ok=True)
@@ -194,7 +195,7 @@ def copy_figures(source_dir: Path, output_dir: Path):
 
     copied = 0
     for ext in image_exts:
-        for img_file in source_dir.rglob(f"*{ext}"):
+        for img_file in source_dir.glob(f"*{ext}"):
             dest = figures_dir / img_file.name
             dest.write_bytes(img_file.read_bytes())
             copied += 1

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -61,7 +61,17 @@ def main():
 
     normalized_arxiv_id = safe_arxiv_id(args.arxiv_id)
     paper_dir = args.output_dir / normalized_arxiv_id
-    source_dir = paper_dir / "source"
+    if args.tex_file:
+        # Explicit entrypoint overrides source_dir so the recovery rerun is
+        # self-contained: a user copying the suggested command from a
+        # different cwd or without re-passing --output-dir must not hit
+        # "Source directory not found" before the explicit file is even
+        # used. Post-processing (title extraction and figure copy) also
+        # operates on the chosen file's sibling directory, which is the
+        # right scope when the real entrypoint lives in a subdirectory.
+        source_dir = args.tex_file.resolve().parent
+    else:
+        source_dir = paper_dir / "source"
 
     print("=" * 60)
     print(f"arXiv Paper to Markdown Converter")

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -86,9 +86,16 @@ def main():
     print("Step 2: Converting to Markdown...")
     print("-" * 60)
 
-    # Check if source is available
-    if source_dir.exists() and list(source_dir.glob("*.tex")):
-        print("LaTeX source detected, using LaTeX conversion...")
+    # Decide LaTeX vs PDF path. An explicit --tex-file always forces the
+    # LaTeX path: the auto-detection here only globs the top level of
+    # source/, but some arXiv layouts put the real entrypoint in a
+    # subdirectory, and --tex-file is advertised as a direct override.
+    has_top_level_tex = source_dir.exists() and list(source_dir.glob("*.tex"))
+    if args.tex_file or has_top_level_tex:
+        if args.tex_file:
+            print(f"Using explicit --tex-file {args.tex_file}, running LaTeX conversion...")
+        else:
+            print("LaTeX source detected, using LaTeX conversion...")
         latex_args = [
             args.arxiv_id,
             "--source-dir",

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -61,29 +61,7 @@ def main():
 
     normalized_arxiv_id = safe_arxiv_id(args.arxiv_id)
     paper_dir = args.output_dir / normalized_arxiv_id
-    if args.tex_file:
-        # Explicit entrypoint overrides source_dir so the recovery rerun is
-        # self-contained: a user copying the suggested command from a
-        # different cwd or without re-passing --output-dir must not hit
-        # "Source directory not found" before the explicit file is even
-        # used.
-        #
-        # Walk up from the chosen file to find the extracted tree root —
-        # by convention convert_paper.py extracts archives into
-        # <paper_dir>/source/, so the nearest ancestor named "source" is
-        # the correct root. Using the tree root (not the chosen file's
-        # immediate parent) matters because figures can live above the
-        # entrypoint, e.g. source/subdir/main.tex referencing
-        # \includegraphics{../fig1.png} in source/fig1.png. Fall back to
-        # the immediate parent for non-standard layouts.
-        resolved_tex = args.tex_file.resolve()
-        source_dir = resolved_tex.parent
-        for ancestor in resolved_tex.parents:
-            if ancestor.name == "source":
-                source_dir = ancestor
-                break
-    else:
-        source_dir = paper_dir / "source"
+    source_dir = paper_dir / "source"
 
     print("=" * 60)
     print(f"arXiv Paper to Markdown Converter")

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -16,8 +16,14 @@ def safe_arxiv_id(arxiv_id: str) -> str:
     return arxiv_id.replace("/", "_")
 
 
-def run_script(script_name: str, args: list, use_uv: bool = False) -> bool:
-    """Run a Python script with arguments."""
+def run_script(script_name: str, args: list, use_uv: bool = False) -> int:
+    """Run a Python script with arguments and return its exit code.
+
+    Returning the raw returncode (instead of a bool) lets callers distinguish
+    semantically meaningful non-zero codes — e.g., exit code 2 from
+    convert_latex.py signals "ambiguous main .tex" and must be propagated
+    instead of collapsed into a generic failure.
+    """
     script_path = Path(__file__).parent / script_name
     if use_uv:
         cmd = ["uv", "run", "--no-project", str(script_path)] + args
@@ -25,7 +31,7 @@ def run_script(script_name: str, args: list, use_uv: bool = False) -> bool:
         cmd = [sys.executable, str(script_path)] + args
 
     result = subprocess.run(cmd)
-    return result.returncode == 0
+    return result.returncode
 
 
 def main():
@@ -44,6 +50,12 @@ def main():
         action="store_true",
         help="Skip fetching (use existing files)"
     )
+    parser.add_argument(
+        "--tex-file",
+        type=Path,
+        help="Specify the main .tex file directly "
+             "(required when multiple \\documentclass files are present)"
+    )
 
     args = parser.parse_args()
 
@@ -61,10 +73,11 @@ def main():
     if not args.skip_fetch:
         print("Step 1: Fetching paper materials...")
         print("-" * 60)
-        if not run_script(
+        rc = run_script(
             "fetch_paper.py",
             [args.arxiv_id, "--output-dir", str(args.output_dir)]
-        ):
+        )
+        if rc != 0:
             print("\n✗ Fetching failed")
             sys.exit(1)
         print()
@@ -76,16 +89,22 @@ def main():
     # Check if source is available
     if source_dir.exists() and list(source_dir.glob("*.tex")):
         print("LaTeX source detected, using LaTeX conversion...")
-        if not run_script(
-            "convert_latex.py",
-            [
-                args.arxiv_id,
-                "--source-dir",
-                str(source_dir),
-                "--output",
-                str(paper_dir / f"{normalized_arxiv_id}.md"),
-            ]
-        ):
+        latex_args = [
+            args.arxiv_id,
+            "--source-dir",
+            str(source_dir),
+            "--output",
+            str(paper_dir / f"{normalized_arxiv_id}.md"),
+        ]
+        if args.tex_file:
+            latex_args += ["--tex-file", str(args.tex_file)]
+        rc = run_script("convert_latex.py", latex_args)
+        if rc != 0:
+            # Exit code 2 signals ambiguous main .tex — the child already
+            # printed a detailed stderr message with candidate paths and
+            # a re-run suggestion, so we just propagate the code.
+            if rc == 2:
+                sys.exit(2)
             print("\n✗ LaTeX conversion failed")
             sys.exit(1)
     else:
@@ -98,11 +117,12 @@ def main():
             print(f"✗ PDF file not found in {paper_dir}")
             sys.exit(1)
 
-        if not run_script(
+        rc = run_script(
             "convert_pdf_simple.py",
             [str(pdf_file), "-o", str(paper_dir / f"{normalized_arxiv_id}.md")],
             use_uv=True,
-        ):
+        )
+        if rc != 0:
             print("\n✗ PDF conversion failed")
             sys.exit(1)
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -66,10 +66,22 @@ def main():
         # self-contained: a user copying the suggested command from a
         # different cwd or without re-passing --output-dir must not hit
         # "Source directory not found" before the explicit file is even
-        # used. Post-processing (title extraction and figure copy) also
-        # operates on the chosen file's sibling directory, which is the
-        # right scope when the real entrypoint lives in a subdirectory.
-        source_dir = args.tex_file.resolve().parent
+        # used.
+        #
+        # Walk up from the chosen file to find the extracted tree root —
+        # by convention convert_paper.py extracts archives into
+        # <paper_dir>/source/, so the nearest ancestor named "source" is
+        # the correct root. Using the tree root (not the chosen file's
+        # immediate parent) matters because figures can live above the
+        # entrypoint, e.g. source/subdir/main.tex referencing
+        # \includegraphics{../fig1.png} in source/fig1.png. Fall back to
+        # the immediate parent for non-standard layouts.
+        resolved_tex = args.tex_file.resolve()
+        source_dir = resolved_tex.parent
+        for ancestor in resolved_tex.parents:
+            if ancestor.name == "source":
+                source_dir = ancestor
+                break
     else:
         source_dir = paper_dir / "source"
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_paper_routing.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_paper_routing.py
@@ -1,0 +1,65 @@
+"""Contract tests for convert-paper routing decisions.
+
+Contract: an explicit --tex-file override must always route to the
+LaTeX conversion path, regardless of what the top-level source/*.tex
+auto-detection finds. Silently falling through to the PDF branch (or
+any other path) would make the explicit override unusable for source
+layouts where the real entrypoint lives in a subdirectory, or where
+source/ contains no top-level .tex files at all.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_tex_file_forces_latex_path_even_with_no_top_level_tex(tmp_path):
+    # Build a source tree that has NO top-level .tex under source/ —
+    # only a subdirectory entrypoint. Without the override guard,
+    # auto-detection would fall through to the PDF branch and exit with
+    # "PDF file not found", ignoring the user's explicit --tex-file.
+    arxiv_id = "test-routing-id"
+    paper_dir = tmp_path / arxiv_id
+    source_dir = paper_dir / "source"
+    subdir = source_dir / "sub"
+    subdir.mkdir(parents=True)
+    tex_file = subdir / "main.tex"
+    # A minimally valid LaTeX document. We do not care whether pandoc
+    # can actually convert it — the contract is about routing only, and
+    # the routing decision happens and is logged before convert_latex
+    # ever invokes pandoc.
+    tex_file.write_text(
+        "\\documentclass{article}\n\\begin{document}\nhi\n\\end{document}\n",
+        encoding="utf-8",
+    )
+
+    script = Path(__file__).parent / "convert_paper.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            arxiv_id,
+            "--skip-fetch",
+            "--output-dir",
+            str(tmp_path),
+            "--tex-file",
+            str(tex_file),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    # Positive assertion: the explicit-override routing marker must be
+    # printed, proving the LaTeX branch was entered.
+    assert "Using explicit --tex-file" in result.stdout, (
+        "Expected convert-paper to route to LaTeX on --tex-file override.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    # Negative assertion: the PDF branch must NOT have been taken. Its
+    # own marker string would indicate a routing regression.
+    assert "No LaTeX source, using PDF conversion" not in result.stdout, (
+        "convert-paper silently fell through to the PDF branch despite "
+        "--tex-file being explicitly provided.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_find_main_tex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_find_main_tex.py
@@ -1,0 +1,91 @@
+"""Contract tests for main .tex discovery.
+
+Contract: find_main_tex must never silently guess between multiple
+\\documentclass files. Conventional names (main.tex, paper.tex, ms.tex,
+article.tex) take precedence; if none match and more than one
+\\documentclass file is present, it must raise AmbiguousMainTexError so
+the caller can fail explicitly and require --tex-file on re-run.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from arxiv_doc_builder.convert_latex import (
+    AmbiguousMainTexError,
+    find_main_tex,
+)
+
+
+def _write_tex(dir_: Path, name: str, with_documentclass: bool = True) -> Path:
+    path = dir_ / name
+    body = "\\documentclass{article}\n" if with_documentclass else ""
+    body += "\\begin{document}\nhello\n\\end{document}\n"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_known_name_wins_over_ambiguity(tmp_path):
+    # Even with multiple \documentclass files, a conventional main.tex
+    # must short-circuit the ambiguity check.
+    main = _write_tex(tmp_path, "main.tex")
+    _write_tex(tmp_path, "supplement.tex")
+    _write_tex(tmp_path, "appendix.tex")
+
+    assert find_main_tex(tmp_path) == main
+
+
+def test_single_documentclass_returned(tmp_path):
+    only = _write_tex(tmp_path, "foo.tex")
+    # A file without \documentclass must not count as a candidate.
+    _write_tex(tmp_path, "bar.tex", with_documentclass=False)
+
+    assert find_main_tex(tmp_path) == only
+
+
+def test_multiple_documentclass_raises(tmp_path):
+    a = _write_tex(tmp_path, "alpha.tex")
+    b = _write_tex(tmp_path, "beta.tex")
+
+    with pytest.raises(AmbiguousMainTexError) as exc_info:
+        find_main_tex(tmp_path)
+
+    # All candidates must be reported so the caller can surface them.
+    assert set(exc_info.value.candidates) == {a, b}
+
+
+def test_no_tex_files_returns_none(tmp_path):
+    assert find_main_tex(tmp_path) is None
+
+
+def test_cli_exits_2_on_ambiguity_with_candidates_in_stderr(tmp_path):
+    # End-to-end CLI contract: invoking convert_latex.py against an
+    # ambiguous source dir must exit 2 and report every candidate on stderr.
+    # This guards against future refactors that swallow the exception.
+    _write_tex(tmp_path, "alpha.tex")
+    _write_tex(tmp_path, "beta.tex")
+
+    script = Path(__file__).parent / "convert_latex.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "test-id",
+            "--source-dir",
+            str(tmp_path),
+            "--output",
+            str(tmp_path / "out.md"),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "alpha.tex" in result.stderr
+    assert "beta.tex" in result.stderr
+    assert "--tex-file" in result.stderr


### PR DESCRIPTION
## Summary

- Replace the silent default-[0] main `.tex` selection in `find_main_tex()` with an explicit `AmbiguousMainTexError`. When multiple `\documentclass` files are present and no conventional main name (`main.tex`, `paper.tex`, `ms.tex`, `article.tex`) matches, `convert_latex.py` now prints all candidate paths to stderr, suggests a `--tex-file` rerun, and exits with code **2**.
- `convert-paper` gains a `--tex-file` passthrough and propagates exit code 2 through `run_script` (which now returns the raw `int` returncode), so agents and shells can distinguish ambiguity from generic conversion failure.
- Rewrite the SKILL.md troubleshooting section to describe the new fail-first behavior and the recovery procedure, using `1911.04882` (PRL main paper + independent supplement) as the canonical motivating example.
- Add contract tests covering known-name precedence, single-file pass-through, raised ambiguity, empty directory, and an end-to-end CLI test that pins the exit-code contract via `subprocess.run`.

Silent selection was unsafe for agent-driven workflows: pandoc conversion succeeding on an arbitrarily chosen candidate is not evidence that the correct entry point was picked, so the wrong paper could be converted without anyone noticing. Fail-first forces an explicit acknowledgment through exit code 2.

Closes #4. Follow-up work on `--tex-file` ergonomics for subdirectory entrypoints and path-aware figure/title post-processing is tracked in #5.

## Test plan

- [x] `uv run pytest` — 18 passing (13 baseline + 5 new)
- [x] Codex review loop — no remaining actionable findings on the core fail-first change; deferred post-processor limitations tracked in #5
- [x] Manual review of SKILL.md troubleshooting rendering