### PR TITLE
feat(arxiv-doc-builder): make fetch idempotent and remove --skip-fetch

### DIFF
--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -147,15 +147,15 @@ Error: Found 2 files with \documentclass in /path/to/1911.04882/source:
   - /path/to/1911.04882/source/supplemental_material.tex
 
 Main .tex selection is ambiguous. Re-run with --tex-file pointing at the correct file, e.g.:
-  convert-paper <ARXIV_ID> --skip-fetch --tex-file /path/to/1911.04882/source/main_paper.tex
+  convert-paper <ARXIV_ID> --tex-file /path/to/1911.04882/source/main_paper.tex
 
 If you originally passed --output-dir, include the same value in the re-run.
 ```
 
-To resolve, re-run `convert-paper` with `--tex-file` pointing at the correct main file, combined with `--skip-fetch` to reuse the already-downloaded source:
+To resolve, re-run `convert-paper` with `--tex-file` pointing at the correct main file. The fetch step is idempotent, so the already-downloaded source is reused without touching the network:
 
 ```bash
-convert-paper 1911.04882 --skip-fetch --tex-file /path/to/1911.04882/source/main_paper.tex
+convert-paper 1911.04882 --tex-file /path/to/1911.04882/source/main_paper.tex
 ```
 
 If the original run used `--output-dir`, pass the same value again so that `convert-paper` reconstructs the correct paper directory.

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -268,7 +268,7 @@ def main():
                 file=sys.stderr,
             )
             print(
-                f"  convert-paper <ARXIV_ID> --skip-fetch --tex-file {abs_candidates[0]}",
+                f"  convert-paper <ARXIV_ID> --tex-file {abs_candidates[0]}",
                 file=sys.stderr,
             )
             print(

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -46,11 +46,6 @@ def main():
         help="Output directory (default: current directory)"
     )
     parser.add_argument(
-        "--skip-fetch",
-        action="store_true",
-        help="Skip fetching (use existing files)"
-    )
-    parser.add_argument(
         "--tex-file",
         type=Path,
         help="Specify the main .tex file directly "
@@ -69,18 +64,17 @@ def main():
     print("=" * 60)
     print()
 
-    # Step 1: Fetch materials
-    if not args.skip_fetch:
-        print("Step 1: Fetching paper materials...")
-        print("-" * 60)
-        rc = run_script(
-            "fetch_paper.py",
-            [args.arxiv_id, "--output-dir", str(args.output_dir)]
-        )
-        if rc != 0:
-            print("\n✗ Fetching failed")
-            sys.exit(1)
-        print()
+    # Step 1: Fetch materials (idempotent — skips network when files exist)
+    print("Step 1: Fetching paper materials...")
+    print("-" * 60)
+    rc = run_script(
+        "fetch_paper.py",
+        [args.arxiv_id, "--output-dir", str(args.output_dir)]
+    )
+    if rc != 0:
+        print("\n✗ Fetching failed")
+        sys.exit(1)
+    print()
 
     # Step 2: Convert to Markdown
     print("Step 2: Converting to Markdown...")

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
@@ -102,12 +102,20 @@ def fetch_source(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
       - single gzip-compressed .tex file (common for older papers)
       - plain text .tex file (rare)
 
+    Idempotent: if the source directory already contains at least one
+    ``.tex`` file, the network fetch is skipped entirely.
+
     Returns:
-        True if source was successfully fetched, False otherwise
+        True if source is available (freshly fetched or already present),
+        False if the fetch failed or the source is not available on arXiv.
     """
     source_url = f"https://arxiv.org/src/{arxiv_id}"
     downloaded = output_dir / f"{file_id}-src.tar.gz"
     source_dir = output_dir / "source"
+
+    if source_dir.exists() and any(source_dir.rglob("*.tex")):
+        print(f"✓ Source already present at {source_dir}, skipping fetch")
+        return True
 
     print(f"Fetching source from {source_url}...")
 
@@ -118,6 +126,7 @@ def fetch_source(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
 
     if result.returncode != 0:
         print("Source not available (paper may be PDF-only)")
+        downloaded.unlink(missing_ok=True)
         return False
 
     # Detect file type and extract accordingly
@@ -158,12 +167,21 @@ def fetch_pdf(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
     """
     Fetch PDF from arXiv.
 
+    Idempotent: if the PDF file already exists and is non-empty, the
+    network fetch is skipped. The non-empty check guards against a
+    previous interrupted curl leaving a zero-byte placeholder.
+
     Returns:
-        True if PDF was successfully fetched, False otherwise
+        True if PDF is available (freshly fetched or already present),
+        False if the fetch failed.
     """
     pdf_url = f"https://arxiv.org/pdf/{arxiv_id}.pdf"
     pdf_dir = output_dir / "pdf"
     pdf_file = pdf_dir / f"{file_id}.pdf"
+
+    if pdf_file.exists() and pdf_file.stat().st_size > 0:
+        print(f"✓ PDF already present at {pdf_file}, skipping fetch")
+        return True
 
     print(f"Fetching PDF from {pdf_url}...")
 
@@ -175,6 +193,12 @@ def fetch_pdf(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
 
     if result.returncode != 0:
         print(f"Failed to fetch PDF: {result.stderr.decode()}")
+        pdf_file.unlink(missing_ok=True)
+        return False
+
+    if pdf_file.stat().st_size == 0:
+        print("Failed to fetch PDF: empty response")
+        pdf_file.unlink(missing_ok=True)
         return False
 
     print(f"✓ PDF saved to {pdf_file}")

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
@@ -6,6 +6,7 @@ Tries to fetch LaTeX source first, falls back to PDF if unavailable.
 """
 
 import argparse
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -133,6 +134,7 @@ def fetch_source(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
     file_type = _detect_file_type(downloaded)
     print(f"  Detected source format: {file_type}")
 
+    extract_ok = False
     if file_type == "tar":
         source_dir.mkdir(exist_ok=True)
         result = subprocess.run(
@@ -141,12 +143,12 @@ def fetch_source(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
         )
         if result.returncode != 0:
             print(f"Failed to extract source: {result.stderr.decode()}")
-            return False
-        print(f"✓ Source extracted to {source_dir}")
+        else:
+            print(f"✓ Source extracted to {source_dir}")
+            extract_ok = True
 
     elif file_type == "gzip_single":
-        if not _extract_gzip_single(downloaded, source_dir):
-            return False
+        extract_ok = _extract_gzip_single(downloaded, source_dir)
 
     elif file_type == "latex":
         # Plain uncompressed .tex file
@@ -154,9 +156,15 @@ def fetch_source(arxiv_id: str, output_dir: Path, file_id: str) -> bool:
         dest = source_dir / "main.tex"
         dest.write_bytes(downloaded.read_bytes())
         print(f"✓ Source saved to {dest} (uncompressed)")
+        extract_ok = True
 
     else:
         print(f"Unknown source format: {file_type}")
+
+    if not extract_ok:
+        # Remove partial extraction so it cannot masquerade as a cache hit
+        shutil.rmtree(source_dir, ignore_errors=True)
+        downloaded.unlink(missing_ok=True)
         return False
 
     downloaded.unlink()  # Clean up downloaded file

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_paper_routing.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_paper_routing.py
@@ -32,6 +32,11 @@ def test_tex_file_forces_latex_path_even_with_no_top_level_tex(tmp_path):
         "\\documentclass{article}\n\\begin{document}\nhi\n\\end{document}\n",
         encoding="utf-8",
     )
+    # Seed a non-empty PDF so the idempotent fetch_pdf() skips the
+    # network (existence-based: non-empty file → cache hit).
+    pdf_dir = paper_dir / "pdf"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    (pdf_dir / f"{arxiv_id}.pdf").write_bytes(b"%PDF-stub")
 
     script = Path(__file__).parent / "convert_paper.py"
     result = subprocess.run(
@@ -39,7 +44,6 @@ def test_tex_file_forces_latex_path_even_with_no_top_level_tex(tmp_path):
             sys.executable,
             str(script),
             arxiv_id,
-            "--skip-fetch",
             "--output-dir",
             str(tmp_path),
             "--tex-file",


### PR DESCRIPTION
## Summary

- Make `fetch_paper.py` idempotent: skip network fetch when cached source (.tex files) or PDF (non-empty file) already exists
- Clean up partial files on curl failure so they don't masquerade as valid cache
- Remove `--skip-fetch` flag from `convert_paper.py` (breaking change — the flag only existed as a workaround for non-idempotent fetch)
- Update error messages and documentation to remove `--skip-fetch` references

Closes #7

## Test plan

- [x] All 19 existing tests pass (including routing contract test updated for idempotent fetch)
- [x] Manual: `convert-paper <ID>` fetches on first run, skips on second run
- [x] Manual: interrupt `convert-paper` mid-download, re-run succeeds (partial file cleaned up)