### PR TITLE
docs(arxiv-doc-builder): reframe PDF fallback as naive output

### DIFF
--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arxiv-doc-builder
-description: Automatically convert arXiv papers to well-structured Markdown documentation. Invoke with an arXiv ID to fetch materials (LaTeX source or PDF), convert to Markdown, and generate implementation-ready reference documentation with preserved mathematics and section structure.
+description: Convert arXiv papers to Markdown documentation. Fetches LaTeX source and PDF, converts LaTeX to Markdown via pandoc (happy path). PDF-only papers get a naive single-column fallback — use the specialized PDF scripts for better results.
 ---
 
 # arXiv Document Builder
@@ -12,21 +12,21 @@ Automatically converts arXiv papers into structured Markdown documentation for i
 This skill automatically:
 
 1. **Fetches paper materials from arXiv**
-   - Attempts to download LaTeX source first (preferred for accuracy)
-   - Falls back to PDF if source is unavailable
+   - Downloads LaTeX source and PDF (idempotent — skips if cached)
    - Handles all HTTP requests, extraction, and directory setup
 
-2. **Converts to structured Markdown**
+2. **Converts LaTeX source to structured Markdown** (happy path)
    - LaTeX source → Markdown via pandoc (preserves all math and structure)
-   - PDF → Markdown via text extraction with multiple conversion modes:
-     - Simple single-column conversion (default)
-     - Full double-column conversion for academic papers
-     - Page-wise extraction with mixed column support
    - Preserves mathematical formulas in MathJax/LaTeX format (`$...$`, `$$...$$`)
    - Maintains section hierarchy and document structure
    - Includes abstracts, figures, and references
 
-3. **Generates implementation-ready documentation**
+3. **PDF fallback** (naive — output quality must be verified)
+   - When no LaTeX source is available, `convert-paper` runs `convert_pdf_simple.py` (single-column pdfplumber extraction) as a best-effort fallback
+   - This produces usable output only for simple, single-column papers
+   - For 2-column papers, math-heavy papers, or complex layouts, inspect the output and use the specialized PDF scripts manually (see below)
+
+4. **Generates implementation-ready documentation**
    - Output saved to `{ARXIV_ID}/{ARXIV_ID}.md` under the output directory (default: current working directory)
    - Easy to reference during code implementation
    - Optimized for Claude to read and understand
@@ -57,20 +57,17 @@ uv run arxiv_doc_builder/convert_paper.py ARXIV_ID [--output-dir DIR]
 - Use absolute paths to control output location precisely.
 
 The orchestrator:
-1. Calls `fetch_paper.py` to download materials (with automatic source→PDF fallback)
+1. Calls `fetch_paper.py` to download source and PDF (idempotent — cached files are reused)
 2. Detects available format (LaTeX source or PDF)
 3. Calls the appropriate converter (`convert_latex.py` or `convert_pdf_simple.py`)
 4. Outputs structured Markdown to `{output-dir}/{ARXIV_ID}/{ARXIV_ID}.md`
 
 All HTTP requests (curl), file extraction (tar), and directory creation (mkdir) are handled automatically.
 
-### Automatic Source Detection and Fallback
+### Source Detection
 
-The fetcher tries LaTeX source first, then PDF:
-- **LaTeX source available**: Downloads `.tar.gz`, extracts to `papers/{ID}/source/`, converts with pandoc
-- **PDF only**: Downloads PDF to `papers/{ID}/pdf/`, extracts text with pdfplumber
-
-No manual intervention needed—the skill handles format detection and fallback automatically.
+- **LaTeX source available**: Converts with pandoc — this is the reliable path
+- **PDF only**: Falls back to naive single-column text extraction. Output quality varies and should be inspected. For better results, use the specialized PDF scripts below
 
 ## Output Structure
 
@@ -86,7 +83,7 @@ Output location: `{output-dir}/{ARXIV_ID}/{ARXIV_ID}.md` (default output-dir is 
 
 ## PDF Conversion Scripts
 
-Three specialized scripts for direct PDF conversion:
+These scripts are **not called by `convert-paper`** — they exist for manual or agent-driven use when the naive fallback produces poor output. Iterate by trying different scripts and inspecting results.
 
 ### convert_pdf_simple.py
 

--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arxiv-doc-builder
-description: Convert arXiv papers to Markdown documentation. Fetches LaTeX source and PDF, converts LaTeX to Markdown via pandoc (happy path). PDF-only papers get a naive single-column fallback — use the specialized PDF scripts for better results.
+description: Convert arXiv papers to Markdown documentation. Fetches available materials from arXiv (LaTeX source when available + PDF), converts LaTeX to Markdown via pandoc (happy path). PDF-only papers get a naive single-column fallback — use the specialized PDF scripts for better results.
 ---
 
 # arXiv Document Builder
@@ -57,7 +57,7 @@ uv run arxiv_doc_builder/convert_paper.py ARXIV_ID [--output-dir DIR]
 - Use absolute paths to control output location precisely.
 
 The orchestrator:
-1. Calls `fetch_paper.py` to download source and PDF (idempotent — cached files are reused)
+1. Calls `fetch_paper.py` to download available materials — source if available + PDF (idempotent — cached files are reused)
 2. Detects available format (LaTeX source or PDF)
 3. Calls the appropriate converter (`convert_latex.py` or `convert_pdf_simple.py`)
 4. Outputs structured Markdown to `{output-dir}/{ARXIV_ID}/{ARXIV_ID}.md`

--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -83,7 +83,7 @@ Output location: `{output-dir}/{ARXIV_ID}/{ARXIV_ID}.md` (default output-dir is 
 
 ## PDF Conversion Scripts
 
-These scripts are **not called by `convert-paper`** — they exist for manual or agent-driven use when the naive fallback produces poor output. Iterate by trying different scripts and inspecting results.
+`convert-paper` only calls `convert_pdf_simple.py` as a naive fallback. The other scripts below are for manual or agent-driven use when the naive output is insufficient. Iterate by trying different scripts and inspecting results.
 
 ### convert_pdf_simple.py
 

--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -12,7 +12,7 @@ Automatically converts arXiv papers into structured Markdown documentation for i
 This skill automatically:
 
 1. **Fetches paper materials from arXiv**
-   - Downloads LaTeX source and PDF (idempotent — skips if cached)
+   - Attempts to download LaTeX source (preferred) and PDF (idempotent — skips if cached)
    - Handles all HTTP requests, extraction, and directory setup
 
 2. **Converts LaTeX source to structured Markdown** (happy path)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -109,7 +109,11 @@ def main():
             print("\n✗ LaTeX conversion failed")
             sys.exit(1)
     else:
-        print("No LaTeX source, using PDF conversion...")
+        print("No LaTeX source, falling back to naive PDF conversion...")
+        print("⚠ This uses single-column text extraction only.")
+        print("  Output quality varies — inspect the result and consider")
+        print("  using convert_pdf_double_column.py or convert_pdf_extract.py")
+        print("  if the output is garbled.")
         # Check both possible PDF locations
         pdf_file = paper_dir / "pdf" / f"{normalized_arxiv_id}.pdf"
         if not pdf_file.exists():

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_paper_routing.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_paper_routing.py
@@ -62,7 +62,7 @@ def test_tex_file_forces_latex_path_even_with_no_top_level_tex(tmp_path):
 
     # Negative assertion: the PDF branch must NOT have been taken. Its
     # own marker string would indicate a routing regression.
-    assert "No LaTeX source, using PDF conversion" not in result.stdout, (
+    assert "falling back to naive PDF conversion" not in result.stdout, (
         "convert-paper silently fell through to the PDF branch despite "
         "--tex-file being explicitly provided.\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"


### PR DESCRIPTION
## Summary

- Reframe SKILL.md: LaTeX conversion is the happy path, PDF fallback is naive single-column extraction that requires output inspection
- Remove "automatic source→PDF fallback" framing from capabilities and orchestrator description
- Add runtime warning in `convert_paper.py` when entering the PDF branch, suggesting specialized scripts
- Clarify that only `convert_pdf_simple.py` is called by `convert-paper`; other PDF scripts are for manual/agent use

Closes #8

## Test plan

- [x] All 19 existing tests pass
- [x] SKILL.md accurately describes convert-paper behavior
- [x] convert_paper.py PDF branch prints warning