### PR TITLE
feat(arxiv-doc-builder): emit provenance frontmatter (LaTeX + PDF)

### DIFF
--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -72,7 +72,10 @@ All HTTP requests (curl), file extraction (tar), and directory creation (mkdir) 
 ## Output Structure
 
 Generated Markdown includes:
-- Title, authors, and abstract
+- A YAML frontmatter block with provenance metadata (title, authors, arXiv id,
+  version, published date, categories, DOI/journal, abstract) — see
+  `references/output-format.md`; the schema is defined by
+  `arxiv_doc_builder/arxiv_metadata.py`
 - Full paper content with section hierarchy
 - Inline math: `$f(x) = x^2$`
 - Display math: `$$\int_0^\infty e^{-x} dx = 1$$`

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Fetch arXiv metadata and render the document frontmatter.
+
+Single source of truth for the YAML frontmatter prepended to a converted
+paper by both conversion paths (``convert_latex.py`` and the PDF path through
+``pdf_converter_lib.py``). The frontmatter is the provenance surface a
+downstream consumer reads, so it must carry the same key set regardless of
+which path produced it or whether the network was reachable.
+
+Design constraints:
+
+- **Runtime is dependency-free.** The LaTeX path runs as a plain ``python3``
+  subprocess with no third-party packages installed, so the frontmatter is
+  hand-emitted rather than routed through PyYAML. A round-trip contract test
+  (which *may* use PyYAML, a test-only dependency) pins the emitted text to
+  valid, re-parseable YAML.
+- **The schema is total.** ``build_frontmatter`` always emits every key, even
+  when the arXiv fetch failed. Unknown values render as YAML null (a bare
+  ``key:``), which a parser reads as ``None``. This deliberately distinguishes
+  "arXiv reported no value" (e.g. a preprint with no journal DOI) from a key
+  that was simply never written — the consumer needs the former for an
+  absence-confirmation ("preprint, no journal DOI") judgement.
+
+Responsibility boundary: the DOI/journal reported here are whatever arXiv's own
+record carries (passive transcription). Resolving a DOI that arXiv does not
+carry (e.g. via OpenAlex) belongs to the arxiv-lookup skill, not here.
+"""
+
+from __future__ import annotations
+
+import re
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Optional
+
+# arXiv's API serves Atom with an arxiv-specific extension namespace; the
+# primary_category / doi / journal_ref fields live in the latter.
+_NS = {
+    "atom": "http://www.w3.org/2005/Atom",
+    "arxiv": "http://arxiv.org/schemas/atom",
+}
+
+_API_URL = "https://export.arxiv.org/api/query"
+
+
+@dataclass
+class ArxivMetadata:
+    """The subset of an arXiv record that the frontmatter transcribes.
+
+    Every field is optional: a failed or partial fetch yields ``None`` / empty
+    lists rather than raising, so callers can always render a (sparser)
+    frontmatter instead of aborting the conversion.
+    """
+
+    title: Optional[str] = None
+    authors: list[str] = field(default_factory=list)
+    version: Optional[str] = None
+    published: Optional[str] = None
+    primary_category: Optional[str] = None
+    categories: list[str] = field(default_factory=list)
+    doi: Optional[str] = None
+    journal: Optional[str] = None
+    abstract: Optional[str] = None
+
+
+def _normalize(text: Optional[str]) -> Optional[str]:
+    """Collapse Atom text whitespace to single spaces.
+
+    arXiv Atom text fields (title, author names, journal_ref, summary) are
+    line-wrapped in the served XML. Collapsing keeps the frontmatter stable and
+    single-line so a double-quoted scalar never has to carry an embedded
+    newline. Returns ``None`` for empty/whitespace-only input.
+    """
+    if text is None:
+        return None
+    collapsed = re.sub(r"\s+", " ", text).strip()
+    return collapsed or None
+
+
+def _text(entry: ET.Element, path: str) -> Optional[str]:
+    """Return the text of the first matching child element, or None."""
+    el = entry.find(path, _NS)
+    return el.text if el is not None else None
+
+
+def parse_version_from_id(id_url: Optional[str]) -> Optional[str]:
+    """Extract the full versioned arXiv id from an Atom ``<id>`` URL.
+
+    Returns the full path tail *including* the version suffix, e.g.
+    ``"2409.03108v2"`` or the legacy ``"hep-th/9901001v3"`` — identical to what
+    the version-drift sidecar persists, so ``fetch_paper`` can delegate here
+    without changing the cached value. Returns ``None`` when no tail is present.
+
+        <id>http://arxiv.org/abs/2409.03108v2</id>     -> "2409.03108v2"
+        <id>http://arxiv.org/abs/hep-th/9901001v3</id> -> "hep-th/9901001v3"
+    """
+    if not id_url:
+        return None
+    path = urllib.parse.urlparse(id_url).path
+    if path.startswith("/abs/"):
+        return path[len("/abs/"):] or None
+    return id_url.rsplit("/", 1)[-1] or None
+
+
+def fetch_metadata(arxiv_id: str, *, timeout: int = 10) -> Optional[ArxivMetadata]:
+    """Fetch the full arXiv record for ``arxiv_id`` in a single API call.
+
+    Returns ``None`` on any network or parse failure so callers can fall back
+    to a local title source (LaTeX ``\\title``, PDF embedded metadata) without
+    special-casing exceptions. Assumes ``arxiv_id`` is already validated to
+    canonical form; no zero-padding is performed here.
+    """
+    url = _API_URL + "?" + urllib.parse.urlencode({"id_list": arxiv_id})
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            tree = ET.parse(resp)
+    except Exception:
+        return None
+
+    entry = tree.find(".//atom:entry", _NS)
+    if entry is None:
+        return None
+
+    primary = entry.find("arxiv:primary_category", _NS)
+    return ArxivMetadata(
+        title=_normalize(_text(entry, "atom:title")),
+        authors=[
+            name
+            for name in (
+                _normalize(n.text)
+                for n in entry.findall("atom:author/atom:name", _NS)
+            )
+            if name
+        ],
+        version=parse_version_from_id(_text(entry, "atom:id")),
+        # arXiv 'published' is an ISO timestamp; the frontmatter keeps the
+        # calendar date (the paper's date), distinct from conversion_date.
+        published=(_text(entry, "atom:published") or "")[:10] or None,
+        primary_category=primary.get("term") if primary is not None else None,
+        categories=[
+            term
+            for term in (
+                c.get("term") for c in entry.findall("atom:category", _NS)
+            )
+            if term
+        ],
+        doi=_normalize(_text(entry, "arxiv:doi")),
+        journal=_normalize(_text(entry, "arxiv:journal_ref")),
+        abstract=_normalize(_text(entry, "atom:summary")),
+    )
+
+
+def _is_yaml_printable(codepoint: int) -> bool:
+    """Whether a code point may appear raw in YAML text.
+
+    Mirrors YAML's ``c-printable`` production (which a parser's reader enforces
+    on the whole stream, before quoting is even considered). Any code point
+    outside this set — C0/C1 controls, DEL, surrogates, the U+FFFE/U+FFFF
+    noncharacters — must be escaped even inside a double-quoted scalar.
+    """
+    return (
+        codepoint in (0x09, 0x0A, 0x0D, 0x85)
+        or 0x20 <= codepoint <= 0x7E
+        or 0xA0 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
+    )
+
+
+def _yaml_dq(value: str) -> str:
+    """Render ``value`` as a YAML double-quoted scalar.
+
+    Total over arbitrary strings: backslash and double-quote are escaped, the
+    line-breaking whitespace is escaped (``\\n`` / ``\\t`` / ``\\r``) to keep the
+    scalar single-line, and any code point YAML cannot carry raw (see
+    ``_is_yaml_printable``) is escaped as ``\\xNN`` / ``\\uNNNN``. A caller
+    therefore cannot emit invalid YAML no matter how an ``ArxivMetadata`` was
+    built — e.g. raw PDF-embedded text (a strict UTF-16BE decode can yield
+    U+FFFF) on the PDF fallback path, which never passes Atom-side validation.
+    """
+    out: list[str] = []
+    for ch in value:
+        codepoint = ord(ch)
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == '"':
+            out.append('\\"')
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\r":
+            out.append("\\r")
+        elif _is_yaml_printable(codepoint):
+            out.append(ch)
+        elif codepoint <= 0xFF:
+            out.append(f"\\x{codepoint:02x}")
+        else:
+            out.append(f"\\u{codepoint:04x}")
+    return '"' + "".join(out) + '"'
+
+
+def _scalar_line(key: str, value: Optional[str]) -> str:
+    """One ``key: "value"`` line, or a bare ``key:`` (YAML null) when absent."""
+    if value is None:
+        return f"{key}:"
+    return f"{key}: {_yaml_dq(value)}"
+
+
+def _list_lines(key: str, items: list[str]) -> str:
+    """A YAML block list, or ``key: []`` when empty."""
+    if not items:
+        return f"{key}: []"
+    body = "\n".join(f"  - {_yaml_dq(item)}" for item in items)
+    return f"{key}:\n{body}"
+
+
+def _block_lines(key: str, value: Optional[str]) -> str:
+    """A literal block scalar (``key: |-``), or a bare ``key:`` when absent.
+
+    ``value`` is whitespace-normalized upstream to a single paragraph, so the
+    block holds one indented line. The ``-`` chomping indicator drops the
+    trailing newline, so the block ends cleanly before the closing fence.
+    """
+    if value is None:
+        return f"{key}:"
+    return f"{key}: |-\n  {value}"
+
+
+def build_frontmatter(
+    meta: Optional[ArxivMetadata],
+    *,
+    arxiv_id: Optional[str],
+    source_type: str,
+    conversion_date: str,
+    fallback_title: Optional[str] = None,
+) -> str:
+    """Render the YAML frontmatter block for a converted paper.
+
+    Every key is always present (a total schema) so a consumer can read
+    provenance from a fixed location regardless of conversion path or whether
+    the arXiv fetch succeeded. ``arxiv_id`` is optional: manual PDF scripts
+    invoke the converter without an id, in which case it renders as null like
+    any other unknown field.
+    """
+    m = meta or ArxivMetadata()
+    # Normalize every emitted text scalar here, so the block is clean and valid
+    # regardless of how the metadata was built — the PDF fallback path
+    # constructs ArxivMetadata straight from raw PDF-embedded strings, which
+    # never passed through the Atom-side normalization in fetch_metadata.
+    title = _normalize(m.title) or _normalize(fallback_title)
+    author_names = [name for name in (_normalize(a) for a in m.authors) if name]
+    authors = ", ".join(author_names) if author_names else None
+
+    lines = [
+        "---",
+        _scalar_line("title", title),
+        _scalar_line("authors", authors),
+        _scalar_line("arxiv_id", arxiv_id),
+        _scalar_line("version", m.version),
+        _scalar_line("published", m.published),
+        _scalar_line("primary_category", m.primary_category),
+        _list_lines("categories", m.categories),
+        _scalar_line("doi", m.doi),
+        _scalar_line("journal", m.journal),
+        _scalar_line("source_type", source_type),
+        _scalar_line("conversion_date", conversion_date),
+        _block_lines("abstract", _normalize(m.abstract)),
+        "---",
+        "",
+        "",
+    ]
+    return "\n".join(lines)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
@@ -65,17 +65,39 @@ class ArxivMetadata:
     abstract: Optional[str] = None
 
 
-def _normalize(text: Optional[str]) -> Optional[str]:
-    """Collapse Atom text whitespace to single spaces.
+def _is_yaml_printable(codepoint: int) -> bool:
+    """Whether a code point may appear raw in YAML text.
 
-    arXiv Atom text fields (title, author names, journal_ref, summary) are
-    line-wrapped in the served XML. Collapsing keeps the frontmatter stable and
-    single-line so a double-quoted scalar never has to carry an embedded
-    newline. Returns ``None`` for empty/whitespace-only input.
+    Mirrors YAML's ``c-printable`` production (which a parser's reader enforces
+    on the whole stream, before quoting is even considered). Code points outside
+    this set — C0/C1 controls, DEL, surrogates, the U+FFFE/U+FFFF noncharacters —
+    are either escaped (in a double-quoted scalar) or stripped (during
+    normalization, for the literal block scalar that cannot escape).
+    """
+    return (
+        codepoint in (0x09, 0x0A, 0x0D, 0x85)
+        or 0x20 <= codepoint <= 0x7E
+        or 0xA0 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
+    )
+
+
+def _normalize(text: Optional[str]) -> Optional[str]:
+    """Make Atom text safe and stable for the frontmatter.
+
+    Two steps: drop characters YAML cannot carry (see ``_is_yaml_printable``),
+    then collapse whitespace runs to single spaces. Stripping is required
+    because the abstract is emitted as a literal block scalar, which — unlike a
+    double-quoted scalar — cannot escape a stray control character; XML 1.0
+    permits raw C1 controls (0x80–0x9F) that YAML forbids, so an arXiv summary
+    can carry one. Collapsing keeps every field single-line. Returns ``None``
+    for empty/whitespace-only input.
     """
     if text is None:
         return None
-    collapsed = re.sub(r"\s+", " ", text).strip()
+    printable = "".join(ch for ch in text if _is_yaml_printable(ord(ch)))
+    collapsed = re.sub(r"\s+", " ", printable).strip()
     return collapsed or None
 
 
@@ -152,33 +174,16 @@ def fetch_metadata(arxiv_id: str, *, timeout: int = 10) -> Optional[ArxivMetadat
     )
 
 
-def _is_yaml_printable(codepoint: int) -> bool:
-    """Whether a code point may appear raw in YAML text.
-
-    Mirrors YAML's ``c-printable`` production (which a parser's reader enforces
-    on the whole stream, before quoting is even considered). Any code point
-    outside this set — C0/C1 controls, DEL, surrogates, the U+FFFE/U+FFFF
-    noncharacters — must be escaped even inside a double-quoted scalar.
-    """
-    return (
-        codepoint in (0x09, 0x0A, 0x0D, 0x85)
-        or 0x20 <= codepoint <= 0x7E
-        or 0xA0 <= codepoint <= 0xD7FF
-        or 0xE000 <= codepoint <= 0xFFFD
-        or 0x10000 <= codepoint <= 0x10FFFF
-    )
-
-
 def _yaml_dq(value: str) -> str:
     """Render ``value`` as a YAML double-quoted scalar.
 
     Total over arbitrary strings: backslash and double-quote are escaped, the
     line-breaking whitespace is escaped (``\\n`` / ``\\t`` / ``\\r``) to keep the
     scalar single-line, and any code point YAML cannot carry raw (see
-    ``_is_yaml_printable``) is escaped as ``\\xNN`` / ``\\uNNNN``. A caller
-    therefore cannot emit invalid YAML no matter how an ``ArxivMetadata`` was
-    built — e.g. raw PDF-embedded text (a strict UTF-16BE decode can yield
-    U+FFFF) on the PDF fallback path, which never passes Atom-side validation.
+    ``_is_yaml_printable``) is escaped as ``\\xNN`` / ``\\uNNNN``. The text
+    fields are already control-stripped by ``_normalize``; the control escaping
+    here is a backstop for the structured fields (id, version, dates) that skip
+    normalization, so the emitter stays valid for any input.
     """
     out: list[str] = []
     for ch in value:
@@ -220,9 +225,11 @@ def _list_lines(key: str, items: list[str]) -> str:
 def _block_lines(key: str, value: Optional[str]) -> str:
     """A literal block scalar (``key: |-``), or a bare ``key:`` when absent.
 
-    ``value`` is whitespace-normalized upstream to a single paragraph, so the
-    block holds one indented line. The ``-`` chomping indicator drops the
-    trailing newline, so the block ends cleanly before the closing fence.
+    ``value`` must be ``_normalize``-d upstream: a literal block scalar cannot
+    escape, so it relies on normalization having stripped YAML-forbidden
+    characters and collapsed the text to a single line. The ``-`` chomping
+    indicator drops the trailing newline, so the block ends cleanly before the
+    closing fence.
     """
     if value is None:
         return f"{key}:"

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -9,9 +9,6 @@ import argparse
 import re
 import subprocess
 import sys
-import urllib.parse
-import urllib.request
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Optional
 
@@ -20,29 +17,12 @@ from typing import Optional
 # arxiv_id.py isn't silently masked by the script-mode fallback.
 try:
     from arxiv_doc_builder.arxiv_id import safe_arxiv_id, validate_arxiv_id
+    from arxiv_doc_builder.arxiv_metadata import build_frontmatter, fetch_metadata
 except ModuleNotFoundError as _exc:
     if _exc.name != "arxiv_doc_builder":
         raise
     from arxiv_id import safe_arxiv_id, validate_arxiv_id
-
-
-def fetch_title_from_arxiv(arxiv_id: str) -> Optional[str]:
-    """Fetch title from arXiv API.
-
-    Assumes ``arxiv_id`` has been validated to canonical form; no
-    zero-padding is performed here.
-    """
-    url = "https://export.arxiv.org/api/query?" + urllib.parse.urlencode({"id_list": arxiv_id})
-    try:
-        with urllib.request.urlopen(url, timeout=10) as resp:
-            tree = ET.parse(resp)
-        ns = {"atom": "http://www.w3.org/2005/Atom"}
-        title_elem = tree.find(".//atom:entry/atom:title", ns)
-        if title_elem is not None and title_elem.text:
-            return re.sub(r"\s+", " ", title_elem.text).strip()
-    except Exception:
-        pass
-    return None
+    from arxiv_metadata import build_frontmatter, fetch_metadata
 
 
 class AmbiguousMainTexError(Exception):
@@ -144,18 +124,16 @@ def post_process_markdown(md_file: Path, arxiv_id: str, source_dir: Path):
 
     content = md_file.read_text(encoding='utf-8')
 
-    # Try arXiv API first, fallback to LaTeX parsing
-    title = fetch_title_from_arxiv(arxiv_id) or extract_title_from_latex(source_dir)
-
-    # Add metadata header
-    header = f"""---
-title: "{title}"
-arxiv_id: "{arxiv_id}"
-source_type: "latex"
-conversion_date: "{datetime.now().isoformat()}"
----
-
-"""
+    # Single arXiv fetch supplies the whole provenance frontmatter; the LaTeX
+    # \title is only a fallback for the title when the network is unreachable.
+    meta = fetch_metadata(arxiv_id)
+    header = build_frontmatter(
+        meta,
+        arxiv_id=arxiv_id,
+        source_type="latex",
+        conversion_date=datetime.now().isoformat(),
+        fallback_title=extract_title_from_latex(source_dir),
+    )
 
     # Fix figure paths (convert to relative paths)
     content = re.sub(
@@ -171,7 +149,7 @@ conversion_date: "{datetime.now().isoformat()}"
     final_content = header + content
     md_file.write_text(final_content, encoding='utf-8')
 
-    print(f"✓ Post-processed Markdown")
+    print("✓ Post-processed Markdown")
 
 
 def copy_figures(source_dir: Path, output_dir: Path):

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -102,13 +102,15 @@ def convert_with_pandoc(tex_file: Path, output_md: Path) -> bool:
     return True
 
 
-def extract_title_from_latex(tex_file: Path) -> str:
+def extract_title_from_latex(tex_file: Path) -> Optional[str]:
     """Extract the paper title from LaTeX source.
 
     Reads the selected main ``.tex`` first so the fallback title belongs to the
     file actually being converted; only if that file carries no ``\\title`` (it
     may sit in an included preamble) does it scan sibling ``.tex`` files, rather
-    than picking an arbitrary file from the directory.
+    than picking an arbitrary file from the directory. Returns ``None`` when no
+    ``\\title`` is found, so an unknown title stays null in the frontmatter
+    rather than a fabricated placeholder (matching the PDF path).
     """
     candidates = [tex_file]
     candidates += sorted(p for p in tex_file.parent.glob("*.tex") if p != tex_file)
@@ -122,8 +124,8 @@ def extract_title_from_latex(tex_file: Path) -> str:
             title = re.sub(r'\\[a-zA-Z]+\s*', '', title)  # Remove commands
             title = re.sub(r'[{}]', '', title)  # Remove braces
             title = re.sub(r'\s+', ' ', title).strip()  # Normalize whitespace
-            return title
-    return "Unknown Title"
+            return title or None
+    return None
 
 
 def post_process_markdown(md_file: Path, arxiv_id: str, tex_file: Path):

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -102,10 +102,18 @@ def convert_with_pandoc(tex_file: Path, output_md: Path) -> bool:
     return True
 
 
-def extract_title_from_latex(source_dir: Path) -> str:
-    """Extract title from LaTeX source files."""
-    for tex_file in source_dir.glob("*.tex"):
-        content = tex_file.read_text(encoding='utf-8', errors='ignore')
+def extract_title_from_latex(tex_file: Path) -> str:
+    """Extract the paper title from LaTeX source.
+
+    Reads the selected main ``.tex`` first so the fallback title belongs to the
+    file actually being converted; only if that file carries no ``\\title`` (it
+    may sit in an included preamble) does it scan sibling ``.tex`` files, rather
+    than picking an arbitrary file from the directory.
+    """
+    candidates = [tex_file]
+    candidates += sorted(p for p in tex_file.parent.glob("*.tex") if p != tex_file)
+    for candidate in candidates:
+        content = candidate.read_text(encoding='utf-8', errors='ignore')
         # Match \title{...} handling nested braces
         match = re.search(r'\\title\s*\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}', content)
         if match:
@@ -118,23 +126,27 @@ def extract_title_from_latex(source_dir: Path) -> str:
     return "Unknown Title"
 
 
-def post_process_markdown(md_file: Path, arxiv_id: str, source_dir: Path):
+def post_process_markdown(md_file: Path, arxiv_id: str, tex_file: Path):
     """Post-process Markdown for better formatting."""
     from datetime import datetime, timezone
 
     content = md_file.read_text(encoding='utf-8')
 
-    # Single arXiv fetch supplies the whole provenance frontmatter; the LaTeX
-    # \title is only a fallback for the title when the network is unreachable.
-    # conversion_date is UTC-aware so the provenance stamp is unambiguous across
-    # environments.
+    # A single arXiv fetch supplies the whole provenance frontmatter; the LaTeX
+    # \title of the converted file is only a fallback for the title, and only
+    # when the arXiv fetch did not provide one (offline / not found). Extracting
+    # it lazily avoids a needless file read on the common path. conversion_date
+    # is UTC-aware so the provenance stamp is unambiguous across environments.
     meta = fetch_metadata(arxiv_id)
+    fallback_title = None
+    if meta is None or not meta.title:
+        fallback_title = extract_title_from_latex(tex_file)
     header = build_frontmatter(
         meta,
         arxiv_id=arxiv_id,
         source_type="latex",
         conversion_date=datetime.now(timezone.utc).isoformat(),
-        fallback_title=extract_title_from_latex(source_dir),
+        fallback_title=fallback_title,
     )
 
     # Fix figure paths (convert to relative paths)
@@ -287,7 +299,7 @@ def main():
         sys.exit(1)
 
     # Post-process
-    post_process_markdown(output_md, args.arxiv_id, source_dir)
+    post_process_markdown(output_md, args.arxiv_id, tex_file)
 
     # Copy figures
     copy_figures(source_dir, output_md.parent)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -120,18 +120,20 @@ def extract_title_from_latex(source_dir: Path) -> str:
 
 def post_process_markdown(md_file: Path, arxiv_id: str, source_dir: Path):
     """Post-process Markdown for better formatting."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     content = md_file.read_text(encoding='utf-8')
 
     # Single arXiv fetch supplies the whole provenance frontmatter; the LaTeX
     # \title is only a fallback for the title when the network is unreachable.
+    # conversion_date is UTC-aware so the provenance stamp is unambiguous across
+    # environments.
     meta = fetch_metadata(arxiv_id)
     header = build_frontmatter(
         meta,
         arxiv_id=arxiv_id,
         source_type="latex",
-        conversion_date=datetime.now().isoformat(),
+        conversion_date=datetime.now(timezone.utc).isoformat(),
         fallback_title=extract_title_from_latex(source_dir),
     )
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_paper.py
@@ -138,7 +138,13 @@ def main():
 
         rc = run_script(
             "convert_pdf_simple.py",
-            [str(pdf_file), "-o", str(paper_dir / f"{normalized_arxiv_id}.md")],
+            [
+                str(pdf_file),
+                "-o",
+                str(paper_dir / f"{normalized_arxiv_id}.md"),
+                "--arxiv-id",
+                args.arxiv_id,
+            ],
             use_uv=True,
         )
         if rc != 0:

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_pdf_simple.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_pdf_simple.py
@@ -32,6 +32,10 @@ def main():
         type=Path,
         help="Output Markdown file path (default: same name as PDF with .md extension)"
     )
+    parser.add_argument(
+        "--arxiv-id",
+        help="arXiv ID for authoritative frontmatter metadata (optional)"
+    )
 
     args = parser.parse_args()
 
@@ -46,7 +50,8 @@ def main():
         pdf_path=args.pdf_path,
         output_path=output_path,
         pages_to_extract=None,  # All pages
-        double_column_pages=None  # Single-column
+        double_column_pages=None,  # Single-column
+        arxiv_id=args.arxiv_id,
     )
 
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
@@ -10,9 +10,6 @@ import json
 import shutil
 import subprocess
 import sys
-import urllib.parse
-import urllib.request
-import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Optional
 
@@ -23,12 +20,14 @@ from typing import Optional
 # fallback — only a genuinely absent top-level package falls through.
 try:
     from arxiv_doc_builder.arxiv_id import safe_arxiv_id, validate_arxiv_id
+    from arxiv_doc_builder.arxiv_metadata import fetch_metadata
 except ModuleNotFoundError as _exc:
     if _exc.name != "arxiv_doc_builder":
         raise
     # Script invocation: script dir is on sys.path[0], so arxiv_id.py is
     # importable as a top-level module.
     from arxiv_id import safe_arxiv_id, validate_arxiv_id
+    from arxiv_metadata import fetch_metadata
 
 
 _METADATA_FILE = ".arxiv-fetch.json"
@@ -41,27 +40,16 @@ def _get_latest_version(arxiv_id: str) -> Optional[str]:
     failure (network error, parse error, offline). ``None`` signals
     that callers should trust the cache.
 
+    Delegates to the shared ``fetch_metadata`` so the Atom request/parse
+    idiom lives in one place; the returned ``version`` is the full versioned
+    tail this drift check persists to the sidecar unchanged. A short timeout
+    keeps the pre-fetch probe lightweight.
+
     Assumes ``arxiv_id`` has already been validated to canonical form
     by ``validate_arxiv_id``; no zero-padding is performed here.
     """
-    url = "https://export.arxiv.org/api/query?" + urllib.parse.urlencode(
-        {"id_list": arxiv_id}
-    )
-    try:
-        with urllib.request.urlopen(url, timeout=5) as resp:
-            tree = ET.parse(resp)
-        ns = {"atom": "http://www.w3.org/2005/Atom"}
-        id_elem = tree.find(".//atom:entry/atom:id", ns)
-        if id_elem is None or not id_elem.text:
-            return None
-        # <id>http://arxiv.org/abs/2409.03108v2</id> → "2409.03108v2"
-        # <id>http://arxiv.org/abs/hep-th/9901001v2</id> → "hep-th/9901001v2"
-        path = urllib.parse.urlparse(id_elem.text).path
-        if path.startswith("/abs/"):
-            return path[len("/abs/"):] or None
-        return id_elem.text.rsplit("/", 1)[-1]
-    except Exception:
-        return None
+    meta = fetch_metadata(arxiv_id, timeout=5)
+    return meta.version if meta else None
 
 
 def _read_cached_version(paper_dir: Path) -> Optional[str]:

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
@@ -69,13 +69,19 @@ def clean_text(text: str) -> str:
 
 
 def extract_metadata(pdf_path: Path) -> dict:
-    """Extract PDF metadata."""
+    """Extract PDF metadata.
+
+    Missing title/author are returned as ``None`` rather than synthesized, so
+    the frontmatter renders them as null ("unknown stays unknown") instead of
+    fabricating a filename-derived title. Callers supply their own display
+    fallback (e.g. the file stem) for human-facing output.
+    """
     reader = PdfReader(pdf_path)
     meta = reader.metadata
 
     return {
-        'title': meta.title if meta and meta.title else pdf_path.stem,
-        'author': meta.author if meta and meta.author else 'Unknown',
+        'title': meta.title if meta and meta.title else None,
+        'author': meta.author if meta and meta.author else None,
         'subject': meta.subject if meta and meta.subject else '',
         'creator': meta.creator if meta and meta.creator else '',
     }
@@ -259,8 +265,8 @@ def convert_pdf_to_markdown(
 
     # Extract metadata
     metadata = extract_metadata(pdf_path)
-    print(f"Title: {metadata['title']}")
-    print(f"Author: {metadata['author']}")
+    print(f"Title: {metadata['title'] or pdf_path.stem}")
+    print(f"Author: {metadata['author'] or 'Unknown'}")
     print()
 
     # Open PDF with pdfplumber
@@ -282,7 +288,7 @@ def convert_pdf_to_markdown(
             pdf_author = metadata["author"]
             meta = ArxivMetadata(
                 title=metadata["title"],
-                authors=[pdf_author] if pdf_author and pdf_author != "Unknown" else [],
+                authors=[pdf_author] if pdf_author else [],
             )
         header = build_frontmatter(
             meta,

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
@@ -5,10 +5,26 @@ Shared library for PDF to Markdown conversion.
 This module provides common functions used by the PDF converter scripts.
 """
 
+from datetime import datetime
 from pathlib import Path
 from typing import Optional, Set
 import pdfplumber
 from pypdf import PdfReader
+
+# Importable both as a package member (pytest) and as a bare sibling module
+# under `uv run --no-project` (the PDF scripts add their own dir to sys.path).
+# Narrow to a missing top-level package so an error inside the module is not
+# masked. arxiv_metadata is stdlib-only, so it imports under the uv env too.
+try:
+    from arxiv_doc_builder.arxiv_metadata import (
+        ArxivMetadata,
+        build_frontmatter,
+        fetch_metadata,
+    )
+except ModuleNotFoundError as _exc:
+    if _exc.name != "arxiv_doc_builder":
+        raise
+    from arxiv_metadata import ArxivMetadata, build_frontmatter, fetch_metadata
 
 
 def parse_page_ranges(range_str: Optional[str]) -> Set[int]:
@@ -214,7 +230,8 @@ def convert_pdf_to_markdown(
     pdf_path: Path,
     output_path: Path,
     pages_to_extract: Optional[Set[int]] = None,
-    double_column_pages: Optional[Set[int]] = None
+    double_column_pages: Optional[Set[int]] = None,
+    arxiv_id: Optional[str] = None,
 ) -> None:
     """
     Convert PDF to Markdown using pdfplumber.
@@ -224,6 +241,10 @@ def convert_pdf_to_markdown(
         output_path: Path to output Markdown file
         pages_to_extract: Set of page numbers to extract (1-indexed). If None, extract all pages.
         double_column_pages: Set of page numbers to process as double-column (1-indexed)
+        arxiv_id: arXiv ID for authoritative metadata. When given, the arXiv
+            record drives the frontmatter; when omitted (manual PDF scripts) or
+            the fetch fails, the PDF's embedded title/author are used and the
+            arXiv-only fields render as null.
     """
     if double_column_pages is None:
         double_column_pages = set()
@@ -251,21 +272,25 @@ def convert_pdf_to_markdown(
         # Prepare markdown content
         markdown_parts = []
 
-        # Add metadata header
-        page_info = f"{len(pages_to_extract)} pages" if pages_to_extract else f"{total_pages} pages"
-        header = f"""# {metadata['title']}
-
-**Author:** {metadata['author']}
-
-**Source:** `{pdf_path.name}`
-
-**Converted:** PDF to Markdown using pdfplumber
-
-**Pages:** {page_info}
-
----
-
-"""
+        # Unified YAML frontmatter (same schema as the LaTeX path). When an
+        # arXiv id is available its record is authoritative; otherwise fall
+        # back to the PDF's embedded title/author, leaving arXiv-only fields
+        # null. The old bold "Source/Converted/Pages" header is intentionally
+        # dropped in favour of this single provenance surface.
+        meta = fetch_metadata(arxiv_id) if arxiv_id else None
+        if meta is None:
+            pdf_author = metadata["author"]
+            meta = ArxivMetadata(
+                title=metadata["title"],
+                authors=[pdf_author] if pdf_author and pdf_author != "Unknown" else [],
+            )
+        header = build_frontmatter(
+            meta,
+            arxiv_id=arxiv_id,
+            source_type="pdf",
+            conversion_date=datetime.now().isoformat(),
+            fallback_title=metadata["title"],
+        )
         markdown_parts.append(header)
 
         # Process each page

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
@@ -5,7 +5,7 @@ Shared library for PDF to Markdown conversion.
 This module provides common functions used by the PDF converter scripts.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Set
 import pdfplumber
@@ -288,7 +288,8 @@ def convert_pdf_to_markdown(
             meta,
             arxiv_id=arxiv_id,
             source_type="pdf",
-            conversion_date=datetime.now().isoformat(),
+            # UTC-aware so the provenance stamp is unambiguous across environments.
+            conversion_date=datetime.now(timezone.utc).isoformat(),
             fallback_title=metadata["title"],
         )
         markdown_parts.append(header)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_arxiv_metadata.py
@@ -1,0 +1,195 @@
+"""Contract tests for the frontmatter producer.
+
+The frontmatter is the provenance surface a downstream consumer reads, so the
+schema must be total (every key always present) and the emitted text must be
+valid, re-parseable YAML — including the absence-confirmation contract where a
+missing arXiv value renders as YAML null rather than an absent key.
+
+The round-trip assertions use PyYAML (a test-only dependency) as an independent
+oracle; ``importorskip`` keeps the suite green in a bare environment without it,
+while the structural assertions below pin the contract with no dependency.
+"""
+
+from arxiv_doc_builder.arxiv_metadata import (
+    ArxivMetadata,
+    build_frontmatter,
+    parse_version_from_id,
+)
+
+# The total key set every frontmatter must carry, in any state.
+FRONTMATTER_KEYS = {
+    "title",
+    "authors",
+    "arxiv_id",
+    "version",
+    "published",
+    "primary_category",
+    "categories",
+    "doi",
+    "journal",
+    "source_type",
+    "conversion_date",
+    "abstract",
+}
+
+_FULL = ArxivMetadata(
+    title="A Study of Things",
+    authors=["Chiara Capecci", "C. Balázs", "C. -P. Yuan"],
+    version="2606.09995v1",
+    published="2026-06-08",
+    primary_category="quant-ph",
+    categories=["quant-ph", "cond-mat.str-el"],
+    doi="10.1103/PhysRevD.76.013009",
+    journal="Phys.Rev.D76:013009,2007",
+    abstract="Line one.\n  wrapped   with   odd spacing\nand a colon: here.",
+)
+
+
+def _parse(frontmatter: str):
+    """Parse the inner YAML of a ``---``-fenced frontmatter block via PyYAML."""
+    import pytest
+
+    yaml = pytest.importorskip("yaml")
+    inner = frontmatter.split("---\n", 1)[1].rsplit("\n---", 1)[0]
+    return yaml.safe_load(inner)
+
+
+# --- structural contract (no third-party dependency) ----------------------
+
+
+def test_all_keys_present_in_full_metadata():
+    fm = build_frontmatter(
+        _FULL, arxiv_id="2606.09995", source_type="latex", conversion_date="2026-06-11T10:00:00"
+    )
+    for key in FRONTMATTER_KEYS:
+        assert f"{key}:" in fm, f"missing key {key!r} in frontmatter"
+    assert fm.startswith("---\n")
+    assert "\n---\n" in fm
+
+
+def test_absent_doi_journal_render_as_bare_null_keys():
+    # The absence-confirmation contract: an arXiv record with no DOI must emit
+    # `doi:` (null), distinct from omitting the key. A bare `key:` line, not
+    # `key: ""`, is what a parser reads as None.
+    meta = ArxivMetadata(title="T", doi=None, journal=None)
+    fm = build_frontmatter(
+        meta, arxiv_id="2606.09995", source_type="latex", conversion_date="d"
+    )
+    assert "\ndoi:\n" in fm
+    assert "\njournal:\n" in fm
+    assert 'doi: ""' not in fm
+
+
+def test_absent_arxiv_id_renders_as_null():
+    # Manual PDF scripts invoke the converter without an id.
+    fm = build_frontmatter(
+        None, arxiv_id=None, source_type="pdf", conversion_date="d", fallback_title="From PDF"
+    )
+    assert "\narxiv_id:\n" in fm
+    assert "From PDF" in fm
+
+
+# --- round-trip contract (PyYAML oracle) ----------------------------------
+
+
+def test_full_metadata_round_trips():
+    fm = build_frontmatter(
+        _FULL, arxiv_id="2606.09995", source_type="latex", conversion_date="2026-06-11T10:00:00"
+    )
+    parsed = _parse(fm)
+
+    assert set(parsed.keys()) == FRONTMATTER_KEYS
+    assert parsed["title"] == "A Study of Things"
+    # Authors are joined into a single citation-friendly string; Unicode is
+    # preserved through the double-quoted scalar.
+    assert parsed["authors"] == "Chiara Capecci, C. Balázs, C. -P. Yuan"
+    assert parsed["arxiv_id"] == "2606.09995"
+    assert parsed["version"] == "2606.09995v1"
+    assert parsed["published"] == "2026-06-08"
+    assert parsed["primary_category"] == "quant-ph"
+    assert parsed["categories"] == ["quant-ph", "cond-mat.str-el"]
+    assert parsed["doi"] == "10.1103/PhysRevD.76.013009"
+    assert parsed["journal"] == "Phys.Rev.D76:013009,2007"
+    assert parsed["source_type"] == "latex"
+    # Abstract is whitespace-normalized to a single paragraph.
+    assert parsed["abstract"] == "Line one. wrapped with odd spacing and a colon: here."
+
+
+def test_absent_fields_parse_to_none():
+    meta = ArxivMetadata(title="T", doi=None, journal=None, abstract=None)
+    parsed = _parse(
+        build_frontmatter(meta, arxiv_id="2606.09995", source_type="latex", conversion_date="d")
+    )
+    assert "doi" in parsed and parsed["doi"] is None
+    assert "journal" in parsed and parsed["journal"] is None
+    assert "abstract" in parsed and parsed["abstract"] is None
+    assert parsed["categories"] == []
+    assert parsed["authors"] is None
+
+
+def test_offline_metadata_keeps_total_schema_with_fallback_title():
+    parsed = _parse(
+        build_frontmatter(
+            None,
+            arxiv_id="2606.09995",
+            source_type="latex",
+            conversion_date="d",
+            fallback_title="LaTeX Title",
+        )
+    )
+    assert set(parsed.keys()) == FRONTMATTER_KEYS
+    assert parsed["title"] == "LaTeX Title"
+    assert parsed["version"] is None
+    assert parsed["arxiv_id"] == "2606.09995"
+
+
+def test_tricky_title_round_trips():
+    meta = ArxivMetadata(title='Tricky: "quotes", colon: and \\backslash')
+    parsed = _parse(
+        build_frontmatter(meta, arxiv_id="x", source_type="latex", conversion_date="d")
+    )
+    assert parsed["title"] == 'Tricky: "quotes", colon: and \\backslash'
+
+
+def test_pdf_style_raw_author_with_newline_stays_valid_yaml():
+    # The PDF fallback path builds ArxivMetadata from raw embedded metadata,
+    # which bypasses the Atom-side normalization. An author carrying an embedded
+    # newline (common in malformed PDF /Author fields) must not corrupt the
+    # YAML; build_frontmatter normalizes it to a single line.
+    meta = ArxivMetadata(title="T", authors=["Jane Doe\n--- affiliation"])
+    parsed = _parse(
+        build_frontmatter(meta, arxiv_id="x", source_type="pdf", conversion_date="d")
+    )
+    assert parsed["authors"] == "Jane Doe --- affiliation"
+
+
+def test_non_printable_characters_stay_valid_yaml():
+    # Every code point YAML forbids raw must be escaped, otherwise PyYAML's
+    # reader rejects the whole scalar. The PDF fallback path is the reachable
+    # threat: raw pypdf metadata bypasses Atom-side validation and can carry
+    # C0/C1 controls, DEL, or — via a strict UTF-16BE decode of \xff\xff —
+    # the U+FFFF noncharacter.
+    title = "A" + "".join(chr(c) for c in (0x07, 0x1B, 0x80, 0x9F, 0x7F, 0xFFFE, 0xFFFF)) + "B"
+    meta = ArxivMetadata(title=title)
+    parsed = _parse(
+        build_frontmatter(meta, arxiv_id="x", source_type="pdf", conversion_date="d")
+    )
+    assert parsed["title"] == title
+
+
+# --- version parsing ------------------------------------------------------
+
+
+def test_parse_version_canonical_full_tail():
+    assert parse_version_from_id("http://arxiv.org/abs/2409.03108v2") == "2409.03108v2"
+
+
+def test_parse_version_legacy_full_tail():
+    # Legacy ids keep their slash and the version suffix; the sidecar stores
+    # exactly this form, so the parser must not strip either.
+    assert parse_version_from_id("http://arxiv.org/abs/hep-th/9901001v3") == "hep-th/9901001v3"
+
+
+def test_parse_version_empty_and_none():
+    assert parse_version_from_id("") is None
+    assert parse_version_from_id(None) is None

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_arxiv_metadata.py
@@ -175,18 +175,25 @@ def test_pdf_style_raw_author_with_newline_stays_valid_yaml():
     assert parsed["authors"] == "Jane Doe --- affiliation"
 
 
-def test_non_printable_characters_stay_valid_yaml():
-    # Every code point YAML forbids raw must be escaped, otherwise PyYAML's
-    # reader rejects the whole scalar. The PDF fallback path is the reachable
-    # threat: raw pypdf metadata bypasses Atom-side validation and can carry
-    # C0/C1 controls, DEL, or — via a strict UTF-16BE decode of \xff\xff —
-    # the U+FFFF noncharacter.
-    title = "A" + "".join(chr(c) for c in (0x07, 0x1B, 0x80, 0x9F, 0x7F, 0xFFFE, 0xFFFF)) + "B"
-    meta = ArxivMetadata(title=title)
+def test_non_printable_characters_are_stripped_and_yaml_stays_valid():
+    # Control characters and the U+FFFE/U+FFFF noncharacters are garbage in
+    # metadata, and the abstract's literal block scalar cannot escape them, so
+    # normalization drops them outright. The frontmatter must stay parseable on
+    # both the quoted-scalar (title, authors) and block-scalar (abstract) paths.
+    # Reachable inputs: XML 1.0 permits raw C1 controls in an arXiv summary, and
+    # pypdf metadata can yield U+FFFF via a strict UTF-16BE decode of \xff\xff.
+    controls = "".join(chr(c) for c in (0x07, 0x1B, 0x80, 0x9F, 0x7F, 0xFFFE, 0xFFFF))
+    meta = ArxivMetadata(
+        title="A" + controls + "B",
+        authors=["Jo" + controls + "hn"],
+        abstract="Clean" + controls + "Abstract",
+    )
     parsed = _parse(
         build_frontmatter(meta, arxiv_id="x", source_type="pdf", conversion_date="d")
     )
-    assert parsed["title"] == title
+    assert parsed["title"] == "AB"
+    assert parsed["authors"] == "John"
+    assert parsed["abstract"] == "CleanAbstract"
 
 
 # --- version parsing ------------------------------------------------------

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_arxiv_metadata.py
@@ -127,6 +127,18 @@ def test_absent_fields_parse_to_none():
     assert parsed["authors"] is None
 
 
+def test_no_metadata_keeps_title_null_not_fabricated():
+    # A PDF with no embedded title and no arXiv id keeps the title null rather
+    # than fabricating one from the file name — "unknown stays unknown".
+    parsed = _parse(
+        build_frontmatter(None, arxiv_id=None, source_type="pdf", conversion_date="d")
+    )
+    assert parsed["title"] is None
+    assert parsed["authors"] is None
+    assert parsed["arxiv_id"] is None
+    assert parsed["source_type"] == "pdf"
+
+
 def test_offline_metadata_keeps_total_schema_with_fallback_title():
     parsed = _parse(
         build_frontmatter(

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_find_main_tex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_find_main_tex.py
@@ -15,6 +15,7 @@ import pytest
 
 from arxiv_doc_builder.convert_latex import (
     AmbiguousMainTexError,
+    extract_title_from_latex,
     find_main_tex,
 )
 
@@ -91,3 +92,32 @@ def test_cli_exits_2_on_ambiguity_with_candidates_in_stderr(tmp_path):
     assert "alpha.tex" in result.stderr
     assert "beta.tex" in result.stderr
     assert "--tex-file" in result.stderr
+
+
+def test_extract_title_uses_selected_tex_not_arbitrary_sibling(tmp_path):
+    # Contract: the fallback title must come from the file actually converted,
+    # not an arbitrary .tex picked from the source directory.
+    (tmp_path / "main.tex").write_text(r"\title{Correct Main Title}", encoding="utf-8")
+    (tmp_path / "supplement.tex").write_text(
+        r"\title{Wrong Supplement Title}", encoding="utf-8"
+    )
+
+    assert extract_title_from_latex(tmp_path / "main.tex") == "Correct Main Title"
+    assert extract_title_from_latex(tmp_path / "supplement.tex") == "Wrong Supplement Title"
+
+
+def test_extract_title_falls_back_to_sibling_when_selected_has_none(tmp_path):
+    # The \title may sit in an included preamble; fall back to siblings rather
+    # than reporting no title.
+    (tmp_path / "main.tex").write_text(r"\documentclass{article}", encoding="utf-8")
+    (tmp_path / "preamble.tex").write_text(r"\title{Title In Preamble}", encoding="utf-8")
+
+    assert extract_title_from_latex(tmp_path / "main.tex") == "Title In Preamble"
+
+
+def test_extract_title_returns_none_when_absent(tmp_path):
+    # No \title anywhere -> None, so the frontmatter title stays null rather than
+    # a fabricated placeholder.
+    (tmp_path / "main.tex").write_text(r"\documentclass{article}", encoding="utf-8")
+
+    assert extract_title_from_latex(tmp_path / "main.tex") is None

--- a/skills/arxiv-doc-builder/pyproject.toml
+++ b/skills/arxiv-doc-builder/pyproject.toml
@@ -13,3 +13,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["arxiv_doc_builder"]
+
+[dependency-groups]
+dev = ["pytest>=8", "pyyaml>=6"]

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -33,7 +33,7 @@ categories:
 doi: "10.1145/1234567.1234568"   # or bare `doi:` (null) when arXiv reports none
 journal: "Proc. ACM, 2024"       # or bare `journal:` (null)
 source_type: "latex"             # or "pdf"
-conversion_date: "2025-12-08T10:00:00"
+conversion_date: "2025-12-08T10:00:00+00:00"
 abstract: |-
   Single-paragraph abstract, whitespace-normalized.
 ---
@@ -44,7 +44,7 @@ Field notes:
 - `version` is the full versioned arXiv id (e.g. `2409.03108v2`, legacy
   `hep-th/9901001v3`), recording which revision was read.
 - `published` is the paper's date (`YYYY-MM-DD`); `conversion_date` is when the
-  conversion ran. They are deliberately distinct.
+  conversion ran (UTC-aware ISO 8601). They are deliberately distinct.
 - `doi` / `journal` are whatever arXiv's own record carries. Resolving a DOI
   that arXiv does not carry (e.g. via OpenAlex) is the arxiv-lookup skill's job,
   not this converter's.

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -1,20 +1,68 @@
 # Output Format Specification
 
-## Standard Markdown Structure
+This document has two kinds of content:
 
-Generated documentation follows this template:
+- **Frontmatter (code-generated).** The YAML frontmatter at the top of every
+  converted paper is emitted by `arxiv_doc_builder/arxiv_metadata.py`
+  (`build_frontmatter`), which is the single source of truth for its schema.
+  The block below documents that schema; the code, not this prose, defines it.
+- **Body formatting (agent-facing).** Everything after the frontmatter — math,
+  figures, tables, code, citations — is guidance for an agent cleaning up or
+  authoring the Markdown by hand. There is no code enforcing it, so it lives
+  here.
+
+## Frontmatter
+
+`build_frontmatter` writes one YAML block keyed identically on both conversion
+paths (LaTeX and PDF). The schema is **total**: every key is always present.
+A value that arXiv does not report renders as YAML null (a bare `key:`), which
+a parser reads as `None` — distinguishing "arXiv reported no value" (e.g. a
+preprint with no journal DOI) from a key that was never written.
+
+```yaml
+---
+title: "Paper Title"
+authors: "Author A, Author B, Author C"
+arxiv_id: "2409.03108"
+version: "2409.03108v2"
+published: "2024-09-04"
+primary_category: "cs.AI"
+categories:
+  - "cs.AI"
+  - "cs.CL"
+doi: "10.1145/1234567.1234568"   # or bare `doi:` (null) when arXiv reports none
+journal: "Proc. ACM, 2024"       # or bare `journal:` (null)
+source_type: "latex"             # or "pdf"
+conversion_date: "2025-12-08T10:00:00"
+abstract: |-
+  Single-paragraph abstract, whitespace-normalized.
+---
+```
+
+Field notes:
+
+- `version` is the full versioned arXiv id (e.g. `2409.03108v2`, legacy
+  `hep-th/9901001v3`), recording which revision was read.
+- `published` is the paper's date (`YYYY-MM-DD`); `conversion_date` is when the
+  conversion ran. They are deliberately distinct.
+- `doi` / `journal` are whatever arXiv's own record carries. Resolving a DOI
+  that arXiv does not carry (e.g. via OpenAlex) is the arxiv-lookup skill's job,
+  not this converter's.
+- When the arXiv fetch fails (offline), the schema still holds: `title` falls
+  back to the LaTeX `\title` or the PDF's embedded title, and the arXiv-only
+  fields render as null. Manual PDF scripts invoked without an id likewise get
+  a valid block with `arxiv_id:` null.
+
+## Body Structure
+
+After the frontmatter, the converted body typically looks like:
 
 ```markdown
-# [Paper Title]
-
-**Authors:** [Author list]
-**arXiv ID:** [ARXIV_ID]
-**Published:** [Date]
-**Categories:** [Categories]
+# Paper Title
 
 ## Abstract
 
-[Abstract text]
+Abstract text (when the source carries it inline).
 
 ## Table of Contents
 
@@ -26,33 +74,22 @@ Generated documentation follows this template:
 
 ## 1. Introduction
 
-[Content...]
+Content...
 
 ### 1.1 Subsection
 
-[Content...]
-
-## 2. Related Work
-
-[Content...]
-
----
-
-## Figures
-
-### Figure 1: [Caption]
-
-![Caption](figures/fig1.png)
-
-[Figure description if available]
+Content...
 
 ---
 
 ## References
 
 [1] Author et al. Title. Conference/Journal, Year.
-[2] ...
 ```
+
+The abstract is also captured in the frontmatter (`abstract:`), so a consumer
+can read it from a fixed location even when the body extraction drops it — a
+common case in the PDF-only fallback.
 
 ## Mathematics Formatting
 
@@ -146,29 +183,13 @@ The method \cite{smith2023} shows promising results.
 [2] Jones, B. (2022). Another Paper. *Journal Name*, 15(3), 789-801.
 ```
 
-## Metadata Header
-
-Include at top of document:
-
-```markdown
----
-title: "Paper Title"
-authors: "Author A, Author B, Author C"
-arxiv_id: "2409.03108"
-published: "2024-09-04"
-categories: "cs.AI, cs.CL"
-source_type: "latex"  # or "pdf"
-conversion_date: "2025-12-08"
----
-```
-
 ## File Organization
 
 ```
 papers/
 └── 2409.03108/
-    ├── 2409.03108.md                # Main document (paper content only)
-    ├── 2409.03108.conversion.toml   # Conversion metadata
+    ├── 2409.03108.md                # Main document (frontmatter + paper content)
+    ├── .arxiv-fetch.json            # Fetch-side version record (drift detection)
     ├── figures/
     │   ├── fig1.png
     │   ├── fig2.png
@@ -184,85 +205,7 @@ papers/
         └── 2409.03108.pdf           # Original PDF
 ```
 
-## Conversion Metadata
-
-Store conversion information in a separate TOML file to keep the Markdown clean and focused on paper content.
-
-### Example: LaTeX Source Conversion
-
-`2409.03108.conversion.toml`:
-```toml
-arxiv_id = "2409.03108"
-title = "Paper Title"
-authors = "Author A, Author B, Author C"
-published = "2024-09-04"
-categories = ["cs.AI", "cs.CL"]
-
-[conversion]
-date = "2025-12-10"
-source_type = "latex"
-method = "pandoc"
-
-[quality]
-math_accuracy = "high"
-figures_extracted = 12
-figures_total = 12
-tables_extracted = 3
-notes = [
-    "All equations preserved in LaTeX notation",
-    "Complete LaTeX source conversion"
-]
-```
-
-### Example: Vision-Based PDF Conversion
-
-`1981.12345.conversion.toml`:
-```toml
-arxiv_id = "1981.12345"
-title = "Hamiltonian Studies of the d = 2 Ashkin-Teller Model"
-authors = "Kohmoto, M., et al."
-published = "1981-06-15"
-categories = ["cond-mat"]
-
-[conversion]
-date = "2025-12-10"
-source_type = "pdf"
-method = "vision"
-dpi = 300
-column_split = true
-
-[quality]
-math_accuracy = "high"
-figures_extracted = 8
-figures_total = 10
-tables_extracted = 2
-notes = [
-    "Vision-based conversion with 300 DPI",
-    "2-column splitting applied for better accuracy",
-    "Small superscripts/subscripts accurately extracted"
-]
-```
-
-### Example: Simple PDF Conversion
-
-`2020.54321.conversion.toml`:
-```toml
-arxiv_id = "2020.54321"
-title = "Modern Paper Example"
-published = "2020-03-15"
-
-[conversion]
-date = "2025-12-10"
-source_type = "pdf"
-method = "simple"  # pdfplumber-based
-
-[quality]
-math_accuracy = "medium"
-figures_extracted = 5
-figures_total = 6
-notes = [
-    "Fast text extraction using pdfplumber",
-    "Some complex formulas may have formatting issues",
-    "Manual verification recommended for mathematical content"
-]
-```
+The provenance metadata lives in the document's YAML frontmatter (see above).
+`.arxiv-fetch.json` is an internal sidecar used only for version-drift
+detection (`{"version": "2409.03108v2"}`); it is not the metadata surface a
+consumer reads.

--- a/skills/arxiv-doc-builder/uv.lock
+++ b/skills/arxiv-doc-builder/uv.lock
@@ -6,3 +6,219 @@ requires-python = ">=3.10"
 name = "arxiv-doc-builder"
 version = "0.2.1"
 source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "pyyaml", specifier = ">=6" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary

`arxiv-doc-builder`'s `references/output-format.md` declared a frontmatter schema the converters never emitted: the LaTeX path wrote only four keys, and the PDF path wrote a `#`-heading + bold block rather than YAML at all. This unifies both conversion paths on a single, total-schema YAML frontmatter, so a downstream consumer can read citation/provenance metadata (authors, version, published, categories, DOI/journal, abstract) from a fixed location. Every emitted field already came from the one arXiv Atom response the code fetched, so the marginal cost is parsing, not extra requests.

## Changes

- `arxiv_doc_builder/arxiv_metadata.py` (new): one arXiv Atom fetch (`fetch_metadata`) plus `build_frontmatter`, the single source of truth for the schema. The frontmatter is hand-emitted to keep the runtime dependency-free; the emitter escapes every code point outside YAML's `c-printable` set, so raw PDF-embedded text cannot produce unparseable output. Absent `doi`/`journal` render as YAML null, distinguishing "arXiv reports none" from an omitted key.
- `convert_latex.py`, `pdf_converter_lib.py`: both paths now emit `build_frontmatter`; the PDF path takes an optional `--arxiv-id` for authoritative metadata and falls back to the PDF's embedded title/author otherwise. The old PDF bold header is dropped.
- `fetch_paper.py`: version lookup delegates to the shared `fetch_metadata`; the `.arxiv-fetch.json` drift sidecar schema is unchanged.
- `convert_pdf_simple.py`, `convert_paper.py`: thread `--arxiv-id` through to the converter.
- `references/output-format.md`, `SKILL.md`: aligned with the code (frontmatter now points to the code as the source of truth; the never-generated `.conversion.toml` section is removed; the body-formatting guidance is kept).

## Test plan

- `arxiv_doc_builder/test_arxiv_metadata.py` (new, 13 cases): total-schema presence, null absence-confirmation, offline fallback-title, YAML safety for control characters / U+FFFE–U+FFFF noncharacters / embedded newlines, and version parsing for canonical and legacy ids. PyYAML is added as a test-only round-trip oracle; the runtime stays zero-dependency.
- `uv run pytest`: 83 passed.
- Manually verified frontmatter output against three live papers: `2606.09995` (no DOI), `0704.0001` (with DOI), `hep-th/9901001` (legacy id).

## Deferred (out of scope)

- Making `.arxiv-fetch.json` a full-record cache to collapse the orchestrated flow to a single arXiv fetch — left out to keep the version-drift path decoupled; per-script call count does not regress (`convert_latex.py` already made exactly one call).
- Wiring `--arxiv-id` into the other manual PDF scripts (`convert_pdf_double_column`, `convert_pdf_extract`, `convert_pdf_split_columns`, `convert_pdf_with_vision`) — `convert_paper.py` only calls `convert_pdf_simple`; the others keep working with a minimal frontmatter (PDF-embedded title/author, arXiv-only fields null).

## Notes

arXiv-reported `doi`/`journal` belong to this converter (passive transcription); resolving a DOI arXiv does not carry (via OpenAlex) stays in the `arxiv-lookup` skill.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated Markdown now always includes a complete, deterministic YAML frontmatter with provenance metadata; PDF and CLI flows accept/preserve an arXiv ID so frontmatter can be authoritative, with local title extraction only used as a fallback.

* **Documentation**
  * Output and skill docs clarify the frontmatter schema as the single source of truth and explain body vs. frontmatter roles.

* **Tests**
  * Added tests for frontmatter generation, YAML escaping, version parsing, and offline/missing-data behavior.

* **Chores**
  * Added dev dependencies for testing and YAML parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->