### PR TITLE
feat(arxiv-doc-builder): bound pandoc with a timeout and RSS watchdog

### DIFF
--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -188,6 +188,70 @@ When pandoc fails on a LaTeX source, the error may point to `\end{document}` wit
 
 The source `(see, e.g., {\cite{makhlin})` has an unmatched `{`. LaTeX compiles fine but pandoc fails. Fix: remove the stray `{`.
 
+## Troubleshooting: Conversion Hangs / Runaway Memory (pandoc never returns)
+
+A brace-mismatch failure is *fast* — pandoc errors in seconds. A different failure mode is the **hang**: `convert-paper` never returns. `convert_latex.py` bounds pandoc on two axes so this surfaces as a fast error instead of an indefinite hang (both env-overridable):
+
+- **Wall-clock timeout** (`PANDOC_TIMEOUT_SECONDS`, default 180s; `ARXIV_PANDOC_TIMEOUT`). This is the *reliable* control — every observed runaway is killed by it.
+- **RSS watchdog** (`PANDOC_RSS_CAP_MB`, default 8192; `ARXIV_PANDOC_RSS_CAP_MB`). Polls the child's real resident memory and kills early; defense-in-depth for a fast-allocating runaway the timeout alone wouldn't contain in time.
+
+Why both, and not the obvious one-liners: observed runaways come in two shapes — a CPU spin at flat memory, and a slow leak (~10 MB/s, reaching tens of GB only after *many minutes*). A timeout catches both, and for the slow leak it also bounds peak memory (≈ timeout × leak-rate, so ~1.8 GB at 180s). A memory cap alone would miss the CPU-spin shape. The naive memory caps were **measured not to work** on this failure: GHC's `pandoc +RTS -M2g -RTS` heap limit did not stop the runaway (major-GC checks don't fire fast enough), and a macOS `RLIMIT_AS` cap (4/8/16 GB) didn't kill it either (enforcement is unreliable and collides with the GHC RTS reserving a huge virtual address space). Hence the watchdog polls **RSS externally** (`ps -o rss=`), which is what actually correlates with swap thrash. You may still hit a hang when driving pandoc manually without these bounds.
+
+### Is it slow or hung?
+
+Find the pandoc PID (`ps aux | rg pandoc`) and read its state in one shot:
+
+```bash
+ps -o pid,etime,time,%cpu,rss,state -p <PID>
+```
+
+- the **state** column shows `R` (running) and CPU `time` tracks `etime` → on-CPU (slow or runaway), not deadlocked.
+- **`rss` climbing into the GB/tens-of-GB** → a parser blowup that will not finish. (A 100-page paper converts in seconds and well under ~1 GB.)
+- The output `.md` size is **not** a progress signal: pandoc buffers the whole document and writes it only at the end (0 bytes until done).
+
+### Root cause: pandoc reads bundled style `.sty` files
+
+pandoc's only channel from a `.sty` is the **macro table** it extracts (there is no per-package special-casing for names like `arxiv`). arXiv source tarballs commonly *bundle* a style file (`arxiv.sty`, conference styles, classicthesis-derived headers) right in the source directory, and pandoc reads any local `.sty` whose name matches a `\usepackage`. The blowup is triggered by a **self-referential macro redefinition that is then invoked**, e.g. the "reduced leading" idiom:
+
+```latex
+\renewcommand{\normalsize}{\@setfontsize\normalsize\@xpt\@xipt ...}
+\normalsize   % invoking it
+```
+
+TeX is fine (`\@setfontsize` consumes `\normalsize` as a non-expanded argument); pandoc does not know `\@setfontsize`, so on the invocation it re-expands `\normalsize` inside its own body without bound. Verified minimal repro: self-reference **+ invocation** blows up; the same definition **without** invocation, or a non-self-referential body, converts instantly.
+
+### Fix: strip the style-only `.sty` (safe, and provably output-neutral here)
+
+Move the style `.sty` out of the source directory (reversible) or comment its `\usepackage`, then re-run — the fetch step is idempotent, so the cached source is reused:
+
+```bash
+mv source/arxiv.sty source/arxiv.sty.bak   # pandoc no longer reads it
+```
+
+Removing a `.sty` is **not** a blanket no-op, but the impact is decidable: it changes output only on `(commands the .sty defines/redefines) ∩ (commands used in the body)`. For a style-only package that intersection is layout scaffolding — `\section`/`\subsection`/`\maketitle` (which pandoc renders *better* from its built-ins; the `.sty`'s `\@startsection` redefinition actually mangles headings) plus front-matter like `\keywords`. Prose, math, citations, and glossary terms are untouched. Before stripping, confirm the `.sty` defines no **content macro** used in the body (e.g. `\newcommand{\co}{ACME}`); if it does, that text would be lost and you must instead provide a stub (next section). For style-only packages the intersection contains no content macro, so stripping is output-equivalent on the substantive content.
+
+## Troubleshooting: glossaries / cleveref and other unknown-arity macros
+
+Symptom: a fast `unexpected (` / `unexpected [` error, often reported at `\begin{document}` (the real cause is elsewhere — pandoc parsed to a boundary). Cause: a heavily-used package whose commands take **optional arguments** pandoc doesn't know the arity of — most commonly `glossaries` / `glossaries-extra` (`\gls`, `\glspl`, `\glsxtrlong`, …, including the `\gls[prereset]{key}` optional-arg form) and `cleveref` (`\cref`). pandoc mis-counts the braces it should consume and breaks once enough body follows.
+
+Fix: inject **arity-correct `\providecommand` stubs** (optional-argument-tolerant) just before `\begin{document}`. `\providecommand` only defines them because pandoc never loaded the real package:
+
+```latex
+\makeatletter
+\providecommand{\gls}[2][]{#2}\providecommand{\glspl}[2][]{#2}
+\providecommand{\Gls}[2][]{#2}\providecommand{\Glspl}[2][]{#2}
+\providecommand{\glsxtrlong}[2][]{#2}\providecommand{\glsxtrlongpl}[2][]{#2}
+\providecommand{\glsxtrshort}[2][]{#2}\providecommand{\glsxtrshortpl}[2][]{#2}
+\providecommand{\glsentryshort}[1]{#1}\providecommand{\glsentrylong}[1]{#1}
+\providecommand{\glslink}[3][]{#3}\providecommand{\glsadd}[2][]{}
+\providecommand{\cref}[1]{#1}\providecommand{\Cref}[1]{#1}
+\makeatother
+```
+
+Quality note: this expands `\gls{AF}` to its **key** (`AF`), not the glossary long form ("activation function") — pandoc cannot resolve the glossary database. Keys are usually readable (`ReLU`, `NN`, `tanh`), which is acceptable for an implementation-reference doc; `\cref{sec:x}` likewise renders as the label `sec:x`, not a link.
+
+This is a *targeted* exception to the "no broad preprocessing" rule above: stubbing a fixed set of known unknown-arity commands, not rewriting the document.
+
 ## Directory Structure
 
 Output is created under `--output-dir` (default: current working directory):

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -8,6 +8,7 @@ Uses pandoc for conversion, with post-processing for better formatting.
 import argparse
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -77,21 +78,30 @@ def find_main_tex(source_dir: Path) -> Optional[Path]:
 
 def _int_env(name: str, default: int) -> int:
     """Read an int env override, falling back to ``default`` when the var is
-    unset or non-numeric. Parsing here (rather than inline at the constant)
-    keeps a malformed override — e.g. ``ARXIV_PANDOC_TIMEOUT=3m`` — from raising
-    at import time and crashing every command in the tool before it even starts.
+    unset, non-numeric, or non-positive. Parsing here (rather than inline at the
+    constant) keeps a malformed override — e.g. ``ARXIV_PANDOC_TIMEOUT=3m`` —
+    from raising at import time and crashing every command before it starts.
     """
     raw = os.environ.get(name)
     if raw is None:
         return default
     try:
-        return int(raw)
+        value = int(raw)
     except ValueError:
         print(
             f"Ignoring non-integer {name}={raw!r}; using {default}.",
             file=sys.stderr,
         )
         return default
+    # Both bounds must be positive: a zero/negative timeout or RSS cap would trip
+    # immediately and kill every conversion, so reject those like a parse error.
+    if value <= 0:
+        print(
+            f"Ignoring non-positive {name}={raw!r}; using {default}.",
+            file=sys.stderr,
+        )
+        return default
+    return value
 
 
 # A clean LaTeX->Markdown conversion finishes in seconds even for a 100-page,
@@ -130,11 +140,16 @@ def _process_rss_mb(pid: int) -> Optional[int]:
     Shells out to `ps -o rss=` (KB) rather than taking a psutil dependency;
     works on the macOS/Linux targets. RSS (not virtual size) is what causes
     swap thrash, and reading it externally sidesteps the GHC RTS reserving a
-    huge virtual address space that defeats RLIMIT_AS-style caps.
+    huge virtual address space that defeats RLIMIT_AS-style caps. `ps` is
+    resolved to an absolute path so a `.`-in-PATH setup can't run a planted
+    binary from the (untrusted) source tree this tool runs subprocesses in.
     """
+    ps_bin = shutil.which("ps")
+    if ps_bin is None:
+        return None
     try:
         out = subprocess.run(
-            ["ps", "-o", "rss=", "-p", str(pid)],
+            [ps_bin, "-o", "rss=", "-p", str(pid)],
             capture_output=True, text=True, timeout=5,
         )
     except (subprocess.SubprocessError, OSError):
@@ -157,6 +172,14 @@ def convert_with_pandoc(
     """
     print(f"Converting {tex_file.name} to Markdown with pandoc...")
 
+    # Resolve pandoc to an absolute path. cwd below is the extracted (untrusted)
+    # source tree, so a bare "pandoc" with `.` in PATH could exec a planted
+    # binary; an absolute path skips PATH lookup in the child entirely.
+    pandoc_bin = shutil.which("pandoc")
+    if pandoc_bin is None:
+        print("Error: pandoc not found on PATH.", file=sys.stderr)
+        return False
+
     # Use absolute paths
     tex_file_abs = tex_file.resolve()
     output_md_abs = output_md.resolve()
@@ -169,7 +192,7 @@ def convert_with_pandoc(
     with tempfile.TemporaryFile() as errf:
         proc = subprocess.Popen(
             [
-                "pandoc",
+                pandoc_bin,
                 str(tex_file_abs),
                 "-f", "latex",
                 "-t", "markdown",

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -145,7 +145,9 @@ def _process_rss_mb(pid: int) -> Optional[int]:
     binary from the (untrusted) source tree this tool runs subprocesses in.
     """
     ps_bin = shutil.which("ps")
-    if ps_bin is None:
+    # shutil.which can return a relative path when PATH holds a relative entry;
+    # that would re-resolve against the untrusted cwd, so require an absolute one.
+    if ps_bin is None or not os.path.isabs(ps_bin):
         return None
     try:
         out = subprocess.run(
@@ -176,8 +178,10 @@ def convert_with_pandoc(
     # source tree, so a bare "pandoc" with `.` in PATH could exec a planted
     # binary; an absolute path skips PATH lookup in the child entirely.
     pandoc_bin = shutil.which("pandoc")
-    if pandoc_bin is None:
-        print("Error: pandoc not found on PATH.", file=sys.stderr)
+    # Require an absolute path: shutil.which can yield a relative one from a
+    # relative PATH entry, which would re-resolve against the untrusted cwd.
+    if pandoc_bin is None or not os.path.isabs(pandoc_bin):
+        print("Error: pandoc not found on PATH as an absolute path.", file=sys.stderr)
         return False
 
     # Use absolute paths

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -6,9 +6,12 @@ Uses pandoc for conversion, with post-processing for better formatting.
 """
 
 import argparse
+import os
 import re
 import subprocess
 import sys
+import tempfile
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -72,30 +75,159 @@ def find_main_tex(source_dir: Path) -> Optional[Path]:
     return None
 
 
-def convert_with_pandoc(tex_file: Path, output_md: Path) -> bool:
-    """Convert LaTeX to Markdown using pandoc."""
+def _int_env(name: str, default: int) -> int:
+    """Read an int env override, falling back to ``default`` when the var is
+    unset or non-numeric. Parsing here (rather than inline at the constant)
+    keeps a malformed override — e.g. ``ARXIV_PANDOC_TIMEOUT=3m`` — from raising
+    at import time and crashing every command in the tool before it even starts.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        print(
+            f"Ignoring non-integer {name}={raw!r}; using {default}.",
+            file=sys.stderr,
+        )
+        return default
+
+
+# A clean LaTeX->Markdown conversion finishes in seconds even for a 100-page,
+# 4000-line paper. When pandoc instead runs unbounded, it is trapped recursively
+# expanding a macro it cannot recognize as a no-op — typically a self-referential
+# redefinition pulled in from a *bundled style .sty* in the source dir, since
+# pandoc reads local .sty files matching a \usepackage. Two observed shapes:
+# a CPU spin at flat memory, and a slow leak (~10 MB/s, reaching tens of GB only
+# after many minutes). Both are caught by the WALL-CLOCK TIMEOUT, which is the
+# only reliable control here — GHC's `+RTS -M` heap cap and a macOS RLIMIT_AS
+# were both measured NOT to stop the runaway. The timeout also indirectly bounds
+# memory for the slow-leak shape (peak ~= timeout * leak-rate). The RSS WATCHDOG
+# is defense-in-depth for a hypothetical fast-allocating runaway the timeout
+# alone would not contain in time: it polls real resident memory (immune to the
+# RTS/rlimit quirks) and kills early. See SKILL.md "Troubleshooting: Conversion
+# Hangs / Runaway Memory". Both bounds are env-overridable for odd edge cases.
+PANDOC_TIMEOUT_SECONDS = _int_env("ARXIV_PANDOC_TIMEOUT", 180)
+PANDOC_RSS_CAP_MB = _int_env("ARXIV_PANDOC_RSS_CAP_MB", 8192)
+_RSS_POLL_SECONDS = 1.0
+# Grace to reap the child after SIGKILL before we stop waiting on it; bounding
+# this wait keeps a wedged child (e.g. uninterruptible sleep) from re-hanging
+# the very call these bounds exist to prevent.
+_KILL_REAP_GRACE_SECONDS = 10
+# Shared remediation tail for both runaway-kill diagnostics (timeout + memory).
+# They describe the same root cause and fix, so the guidance is written once.
+_RUNAWAY_REMEDY = (
+    "Move the style-only .sty out of the source directory (or comment its "
+    "\\usepackage line) and re-run. See SKILL.md 'Troubleshooting: Conversion "
+    "Hangs / Runaway Memory'."
+)
+
+
+def _process_rss_mb(pid: int) -> Optional[int]:
+    """Resident set size of a pid in MB, or None if it can't be read.
+
+    Shells out to `ps -o rss=` (KB) rather than taking a psutil dependency;
+    works on the macOS/Linux targets. RSS (not virtual size) is what causes
+    swap thrash, and reading it externally sidesteps the GHC RTS reserving a
+    huge virtual address space that defeats RLIMIT_AS-style caps.
+    """
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    out = out.stdout.strip()
+    return int(out) // 1024 if out.isdigit() else None
+
+
+def convert_with_pandoc(
+    tex_file: Path,
+    output_md: Path,
+    timeout: int = PANDOC_TIMEOUT_SECONDS,
+    rss_cap_mb: int = PANDOC_RSS_CAP_MB,
+) -> bool:
+    """Convert LaTeX to Markdown using pandoc, bounded in wall-clock and memory.
+
+    Returns False (with a diagnostic on stderr) instead of hanging when pandoc
+    runs away. ``timeout`` is the primary, reliable bound; ``rss_cap_mb`` is a
+    secondary watchdog against fast memory growth.
+    """
     print(f"Converting {tex_file.name} to Markdown with pandoc...")
 
     # Use absolute paths
     tex_file_abs = tex_file.resolve()
     output_md_abs = output_md.resolve()
 
-    result = subprocess.run(
-        [
-            "pandoc",
-            str(tex_file_abs),
-            "-f", "latex",
-            "-t", "markdown",
-            "--wrap=none",
-            "--mathjax",
-            "-o", str(output_md_abs)
-        ],
-        capture_output=True,
-        cwd=str(tex_file.parent.resolve())
-    )
+    # Popen (not subprocess.run) so the loop below can poll RSS while pandoc
+    # runs. pandoc writes the document to -o, so stdout stays empty; stderr goes
+    # to a temp file rather than a PIPE so it can fill without us draining it —
+    # a PIPE left unread during the wait loop could deadlock if pandoc emitted
+    # enough to fill the pipe buffer. The temp file is drained once, after exit.
+    with tempfile.TemporaryFile() as errf:
+        proc = subprocess.Popen(
+            [
+                "pandoc",
+                str(tex_file_abs),
+                "-f", "latex",
+                "-t", "markdown",
+                "--wrap=none",
+                "--mathjax",
+                "-o", str(output_md_abs),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=errf,
+            cwd=str(tex_file.parent.resolve()),
+        )
 
-    if result.returncode != 0:
-        print(f"Pandoc conversion failed: {result.stderr.decode()}")
+        start = time.monotonic()
+        killed_for = None  # "timeout" | "memory" | None
+        while True:
+            try:
+                proc.wait(timeout=_RSS_POLL_SECONDS)
+                break  # finished on its own
+            except subprocess.TimeoutExpired:
+                pass
+            if time.monotonic() - start > timeout:
+                killed_for = "timeout"
+            else:
+                rss = _process_rss_mb(proc.pid)
+                if rss is not None and rss > rss_cap_mb:
+                    killed_for = "memory"
+            if killed_for:
+                proc.kill()
+                try:
+                    proc.wait(timeout=_KILL_REAP_GRACE_SECONDS)
+                except subprocess.TimeoutExpired:
+                    pass  # reaping shouldn't outlast SIGKILL; never re-hang here
+                break
+
+        errf.seek(0)
+        stderr = errf.read().decode(errors="replace")
+
+    if killed_for == "timeout":
+        # Not "slow" — a runaway. Name the most common root cause and the fix.
+        print(
+            f"Pandoc did not finish within {timeout}s and was killed. A normal "
+            "conversion takes seconds; a runaway almost always means pandoc is "
+            "recursively expanding a self-referential macro from a bundled "
+            "style .sty in the source directory (pandoc reads local .sty files "
+            f"matching a \\usepackage). {_RUNAWAY_REMEDY}",
+            file=sys.stderr,
+        )
+        return False
+    if killed_for == "memory":
+        print(
+            f"Pandoc exceeded the {rss_cap_mb} MB memory watchdog and was "
+            "killed (same runaway class as the timeout case — usually a "
+            f"self-referential macro from a bundled style .sty). {_RUNAWAY_REMEDY}",
+            file=sys.stderr,
+        )
+        return False
+    if proc.returncode != 0:
+        print(f"Pandoc conversion failed: {stderr}", file=sys.stderr)
         return False
 
     print(f"✓ Converted to {output_md}")

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
@@ -20,6 +20,14 @@ from arxiv_doc_builder import convert_latex
 from arxiv_doc_builder.convert_latex import _process_rss_mb, convert_with_pandoc
 
 
+@pytest.fixture(autouse=True)
+def _which_resolves_fake(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resolve any binary to a fake absolute path so the suite does not depend on
+    the host actually having pandoc / ps installed (convert_with_pandoc and
+    _process_rss_mb now go through shutil.which before launching a subprocess)."""
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda name: f"/usr/bin/{name}")
+
+
 class _FakeCompleted:
     """Stand-in for subprocess.run's CompletedProcess (stdout only)."""
 
@@ -117,6 +125,23 @@ def test_rss_watchdog_kills_and_returns_false(monkeypatch: pytest.MonkeyPatch) -
     assert proc.killed
 
 
+def test_returns_false_when_pandoc_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Fail closed (not hang, not crash) when pandoc cannot be resolved on PATH.
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda name: None)
+
+    def _no_popen(*a: object, **k: object) -> NoReturn:
+        raise AssertionError("Popen must not run when pandoc is unresolved")
+
+    monkeypatch.setattr(convert_latex.subprocess, "Popen", _no_popen)
+
+    assert convert_with_pandoc(Path("x.tex"), Path("out.md")) is False
+
+
+def test_process_rss_mb_none_when_ps_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda name: None)
+    assert _process_rss_mb(1234) is None
+
+
 def test_success_returns_true_without_kill(monkeypatch: pytest.MonkeyPatch) -> None:
     proc = _FakeProc(finishes=True, returncode=0)
     _patch_popen(monkeypatch, proc)
@@ -180,3 +205,20 @@ def test_int_env_falls_back_on_non_numeric(
     assert convert_latex._int_env("ARXIV_TEST_INT", 7) == 7
     # A malformed override warns on stderr rather than raising (would crash import).
     assert "Ignoring non-integer" in capsys.readouterr().err
+
+
+def test_int_env_falls_back_on_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # 0 is syntactically valid but a zero timeout / RSS cap would trip instantly.
+    monkeypatch.setenv("ARXIV_TEST_INT", "0")
+    assert convert_latex._int_env("ARXIV_TEST_INT", 7) == 7
+    assert "Ignoring non-positive" in capsys.readouterr().err
+
+
+def test_int_env_falls_back_on_negative(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ARXIV_TEST_INT", "-5")
+    assert convert_latex._int_env("ARXIV_TEST_INT", 7) == 7
+    assert "Ignoring non-positive" in capsys.readouterr().err

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
@@ -127,9 +127,9 @@ def test_rss_watchdog_kills_and_returns_false(monkeypatch: pytest.MonkeyPatch) -
 
 def test_returns_false_when_pandoc_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     # Fail closed (not hang, not crash) when pandoc cannot be resolved on PATH.
-    monkeypatch.setattr(convert_latex.shutil, "which", lambda name: None)
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda _name: None)
 
-    def _no_popen(*a: object, **k: object) -> NoReturn:
+    def _no_popen(*_a: object, **_k: object) -> NoReturn:
         raise AssertionError("Popen must not run when pandoc is unresolved")
 
     monkeypatch.setattr(convert_latex.subprocess, "Popen", _no_popen)
@@ -137,8 +137,30 @@ def test_returns_false_when_pandoc_missing(monkeypatch: pytest.MonkeyPatch) -> N
     assert convert_with_pandoc(Path("x.tex"), Path("out.md")) is False
 
 
+def test_returns_false_when_pandoc_path_relative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A relative which() result (relative PATH entry) must be rejected, since it
+    # would re-resolve against the untrusted cwd.
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda _name: "pandoc")
+
+    def _no_popen(*_a: object, **_k: object) -> NoReturn:
+        raise AssertionError("Popen must not run for a relative pandoc path")
+
+    monkeypatch.setattr(convert_latex.subprocess, "Popen", _no_popen)
+
+    assert convert_with_pandoc(Path("x.tex"), Path("out.md")) is False
+
+
 def test_process_rss_mb_none_when_ps_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(convert_latex.shutil, "which", lambda name: None)
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda _name: None)
+    assert _process_rss_mb(1234) is None
+
+
+def test_process_rss_mb_none_when_ps_path_relative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(convert_latex.shutil, "which", lambda _name: "ps")
     assert _process_rss_mb(1234) is None
 
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
@@ -1,0 +1,182 @@
+"""Contract tests for the pandoc runaway bounds in convert_with_pandoc.
+
+Contract: convert_with_pandoc must never hang on a runaway pandoc. It bounds
+execution by a wall-clock timeout and an RSS watchdog; on either trip it kills
+the child and returns False (it does not raise and does not block past the
+timeout). _process_rss_mb must parse `ps -o rss=` output defensively, returning
+None rather than raising when the output is unparseable or `ps` fails.
+
+These use fakes for subprocess.Popen / subprocess.run / time.monotonic so the
+control flow is exercised without depending on a real pandoc or on timing.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import NoReturn
+
+import pytest
+
+from arxiv_doc_builder import convert_latex
+from arxiv_doc_builder.convert_latex import _process_rss_mb, convert_with_pandoc
+
+
+class _FakeCompleted:
+    """Stand-in for subprocess.run's CompletedProcess (stdout only)."""
+
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
+
+
+class _FakeProc:
+    """Stand-in for the Popen handle convert_with_pandoc drives.
+
+    ``finishes`` controls whether ``wait(timeout=...)`` returns or raises
+    TimeoutExpired. ``kill()`` flips it to finished so the subsequent
+    bounded ``wait()`` returns instead of hanging the test.
+    """
+
+    def __init__(self, *, finishes: bool, returncode: int = 0) -> None:
+        self._finishes = finishes
+        self.returncode = returncode
+        self.pid = 4321
+        self.killed = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._finishes:
+            return self.returncode
+        raise subprocess.TimeoutExpired(cmd="pandoc", timeout=timeout)
+
+    def kill(self) -> None:
+        self.killed = True
+        self._finishes = True
+
+
+def _patch_popen(monkeypatch: pytest.MonkeyPatch, proc: _FakeProc) -> None:
+    monkeypatch.setattr(
+        convert_latex.subprocess, "Popen", lambda *a, **k: proc
+    )
+
+
+# ---- _process_rss_mb ----
+
+
+def test_process_rss_mb_parses_kb_to_mb(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        convert_latex.subprocess, "run", lambda *a, **k: _FakeCompleted("2048\n")
+    )
+    assert _process_rss_mb(1234) == 2  # 2048 KB -> 2 MB
+
+
+def test_process_rss_mb_none_on_unparseable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        convert_latex.subprocess, "run", lambda *a, **k: _FakeCompleted("")
+    )
+    assert _process_rss_mb(1234) is None
+
+
+def test_process_rss_mb_none_on_ps_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*a: object, **k: object) -> NoReturn:
+        raise OSError("ps unavailable")
+
+    monkeypatch.setattr(convert_latex.subprocess, "run", boom)
+    assert _process_rss_mb(1234) is None
+
+
+# ---- convert_with_pandoc bounds ----
+
+
+def test_timeout_kills_and_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = _FakeProc(finishes=False)
+    _patch_popen(monkeypatch, proc)
+    # start = 0.0, then the loop's clock reads past the timeout on first check.
+    times = iter([0.0, 1000.0, 1000.0])
+    monkeypatch.setattr(convert_latex.time, "monotonic", lambda: next(times))
+    # RSS stays low so only the timeout can trip.
+    monkeypatch.setattr(convert_latex, "_process_rss_mb", lambda pid: 1)
+
+    ok = convert_with_pandoc(
+        Path("x.tex"), Path("out.md"), timeout=5, rss_cap_mb=8192
+    )
+
+    assert ok is False
+    assert proc.killed
+
+
+def test_rss_watchdog_kills_and_returns_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = _FakeProc(finishes=False)
+    _patch_popen(monkeypatch, proc)
+    # Clock never advances past the (large) timeout, so only RSS can trip.
+    monkeypatch.setattr(convert_latex.time, "monotonic", lambda: 0.0)
+    monkeypatch.setattr(convert_latex, "_process_rss_mb", lambda pid: 9000)
+
+    ok = convert_with_pandoc(
+        Path("x.tex"), Path("out.md"), timeout=300, rss_cap_mb=8192
+    )
+
+    assert ok is False
+    assert proc.killed
+
+
+def test_success_returns_true_without_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = _FakeProc(finishes=True, returncode=0)
+    _patch_popen(monkeypatch, proc)
+    monkeypatch.setattr(convert_latex.time, "monotonic", lambda: 0.0)
+
+    ok = convert_with_pandoc(Path("x.tex"), Path("out.md"))
+
+    assert ok is True
+    assert not proc.killed
+
+
+def test_nonzero_exit_returns_false_without_kill(monkeypatch: pytest.MonkeyPatch) -> None:
+    proc = _FakeProc(finishes=True, returncode=1)
+    _patch_popen(monkeypatch, proc)
+    monkeypatch.setattr(convert_latex.time, "monotonic", lambda: 0.0)
+
+    ok = convert_with_pandoc(Path("x.tex"), Path("out.md"))
+
+    assert ok is False
+    assert not proc.killed
+
+
+def test_post_kill_wait_timeout_does_not_rehang(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A child that does not reap within the post-kill grace window must not
+    # re-hang convert_with_pandoc: the bounded wait swallows TimeoutExpired.
+    class _StuckProc(_FakeProc):
+        def kill(self) -> None:
+            self.killed = True  # but leave _finishes False so wait() keeps raising
+
+    proc = _StuckProc(finishes=False)
+    _patch_popen(monkeypatch, proc)
+    times = iter([0.0, 1000.0, 1000.0])
+    monkeypatch.setattr(convert_latex.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(convert_latex, "_process_rss_mb", lambda pid: 1)
+
+    ok = convert_with_pandoc(Path("x.tex"), Path("out.md"), timeout=5)
+
+    assert ok is False
+    assert proc.killed
+
+
+# ---- _int_env (env-override parsing) ----
+
+
+def test_int_env_uses_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ARXIV_TEST_INT", raising=False)
+    assert convert_latex._int_env("ARXIV_TEST_INT", 7) == 7
+
+
+def test_int_env_parses_valid_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARXIV_TEST_INT", "42")
+    assert convert_latex._int_env("ARXIV_TEST_INT", 7) == 42
+
+
+def test_int_env_falls_back_on_non_numeric(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("ARXIV_TEST_INT", "3m")
+    assert convert_latex._int_env("ARXIV_TEST_INT", 7) == 7
+    # A malformed override warns on stderr rather than raising (would crash import).
+    assert "Ignoring non-integer" in capsys.readouterr().err

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/test_convert_pandoc_bounds.py
@@ -154,6 +154,11 @@ def test_returns_false_when_pandoc_path_relative(
 
 def test_process_rss_mb_none_when_ps_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(convert_latex.shutil, "which", lambda _name: None)
+
+    def _no_run(*_a: object, **_k: object) -> NoReturn:
+        raise AssertionError("subprocess.run must not run when ps is unresolved")
+
+    monkeypatch.setattr(convert_latex.subprocess, "run", _no_run)
     assert _process_rss_mb(1234) is None
 
 
@@ -161,6 +166,12 @@ def test_process_rss_mb_none_when_ps_path_relative(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(convert_latex.shutil, "which", lambda _name: "ps")
+
+    # The relative path must be rejected BEFORE any exec, so run must not fire.
+    def _no_run(*_a: object, **_k: object) -> NoReturn:
+        raise AssertionError("subprocess.run must not run for a relative ps path")
+
+    monkeypatch.setattr(convert_latex.subprocess, "run", _no_run)
     assert _process_rss_mb(1234) is None
 
 


### PR DESCRIPTION
## Summary

pandoc can run away while expanding a self-referential macro it reads from a bundled style `.sty` in the source directory (for example `arxiv.sty`'s reduced-leading `\renewcommand{\normalsize}{...\normalsize...}`, which pandoc re-expands without bound because it does not know `\@setfontsize`). The previous blocking `subprocess.run` call had no bound, so the `convert-paper` CLI would hang indefinitely and grow into tens of GB of resident memory with no signal to the user. This bounds the pandoc invocation so a runaway surfaces as a fast, legible failure instead of an open-ended hang.

## Changes

- `arxiv_doc_builder/convert_latex.py`: replace the blocking pandoc call with a `subprocess.Popen` plus a 1-second polling loop that kills the child on either a wall-clock timeout (`ARXIV_PANDOC_TIMEOUT`, default 180 s) or an RSS watchdog (`ARXIV_PANDOC_RSS_CAP_MB`, default 8192 MB, sampled via `ps -o rss=`). On a kill the function returns `False` with a diagnostic that names the bundled-`.sty` root cause and the remedy (move the style `.sty` out of the source directory and re-run). A new `_int_env` helper reads those env overrides with a fallback, so a malformed value warns instead of raising at import. stderr is routed to a temp file and drained after exit, so the polling loop cannot deadlock on an unread pipe.
- `SKILL.md`: add troubleshooting for the hang — slow-vs-hung diagnosis (`ps -o ...,state` / RSS growth), the bundled-`.sty` self-referential-macro root cause, and a separate `glossaries` / `cleveref` workaround that injects arity-correct `\providecommand` stubs so pandoc stops mis-consuming braces.
- `arxiv_doc_builder/test_convert_pandoc_bounds.py`: new tests covering both kill paths, the bounded post-kill reap, the success and non-zero-exit paths, and the `_int_env` parse branches.

## Test plan

- `uv run pytest`: 98 passed (was 87; +11 new tests for the bounds and env parsing).
- `uv run ruff check`: clean.
- Manual: a minimal self-referential-`.sty` repro is killed at the timeout and returns `False`; a normal paper converts unchanged.

## Notes

- The timeout is the reliable control: GHC's `pandoc +RTS -M` heap cap and a macOS `RLIMIT_AS` cap were both measured not to stop the runaway, so the watchdog samples RSS externally instead. The RSS watchdog is defense-in-depth for a fast-allocating runaway the timeout alone would not contain in time.
- Pre-existing functions in `convert_latex.py` (`main`, `copy_figures`, `post_process_markdown`, `AmbiguousMainTexError.__init__`) still lack return annotations. They are left untouched to keep this change scoped; tightening them could be a separate cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable wall-clock and memory limits for LaTeX-to-Markdown conversion, controllable via environment settings.

* **Bug Fixes**
  * Prevented runaway conversions from hanging by enforcing timeout and memory watchdog termination.
  * Improved handling and messaging when conversion fails.

* **Documentation**
  * Expanded troubleshooting for pandoc runaway memory, including practical mitigation steps.
  * Added guidance for common “unexpected (` / `unexpected [`” LaTeX command arity errors.

* **Tests**
  * Added automated coverage for bounded conversion behavior and limit parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->