### PR TITLE
fix(arxiv-doc-builder): surface arXiv metadata fetch failures

### DIFF
--- a/skills/arxiv-doc-builder/SKILL.md
+++ b/skills/arxiv-doc-builder/SKILL.md
@@ -75,10 +75,9 @@ All HTTP requests (curl), file extraction (tar), and directory creation (mkdir) 
 ## Output Structure
 
 Generated Markdown includes:
-- A YAML frontmatter block with provenance metadata (title, authors, arXiv id,
-  version, published date, categories, DOI/journal, abstract) — see
-  `references/output-format.md`; the schema is defined by
-  `arxiv_doc_builder/arxiv_metadata.py`
+- A YAML frontmatter block with provenance metadata, whose schema
+  `arxiv_doc_builder/arxiv_metadata.py` defines and
+  `references/output-format.md` documents
 - Full paper content with section hierarchy
 - Inline math: `$f(x) = x^2$`
 - Display math: `$$\int_0^\infty e^{-x} dx = 1$$`

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
@@ -16,10 +16,10 @@ Design constraints:
   valid, re-parseable YAML.
 - **The schema is total.** ``build_frontmatter`` always emits every key, even
   when the arXiv fetch failed. Unknown values render as YAML null (a bare
-  ``key:``), which a parser reads as ``None``. This deliberately distinguishes
-  "arXiv reported no value" (e.g. a preprint with no journal DOI) from a key
-  that was simply never written — the consumer needs the former for an
-  absence-confirmation ("preprint, no journal DOI") judgement.
+  ``key:``), which a parser reads as ``None``.
+- **A null is read together with ``metadata_status``.** Only under ``ok`` does a
+  null confirm an absence. Under the other tokens the record was never read, and
+  the null reports ignorance. See ``references/output-format.md``.
 
 Responsibility boundary: the DOI/journal reported here are whatever arXiv's own
 record carries (passive transcription). Resolving a DOI that arXiv does not
@@ -44,14 +44,30 @@ _NS = {
 
 _API_URL = "https://export.arxiv.org/api/query"
 
+# The ``metadata_status`` frontmatter vocabulary. Anything that stops the record
+# from being read gives ``unavailable``, and the warning says what did.
+METADATA_OK = "ok"
+METADATA_UNAVAILABLE = "unavailable"
+METADATA_NOT_REQUESTED = "not_requested"
+
+METADATA_STATUSES = (METADATA_OK, METADATA_UNAVAILABLE, METADATA_NOT_REQUESTED)
+
+# What a fetch can report. ``not_requested`` is a frontmatter token for a
+# document nobody asked arXiv about, and no fetch produces it.
+_FETCH_STATUSES = (METADATA_OK, METADATA_UNAVAILABLE)
+
 
 @dataclass
 class ArxivMetadata:
     """The subset of an arXiv record that the frontmatter transcribes.
 
-    Every field is optional: a failed or partial fetch yields ``None`` / empty
-    lists rather than raising, so callers can always render a (sparser)
-    frontmatter instead of aborting the conversion.
+    Every field is optional. In an instance built from an arXiv record a
+    ``None`` means the record reports no value there.
+
+    The PDF path also builds this type from a PDF's own title and author when no
+    arXiv record backs the document, and then a ``None`` means only that nothing
+    supplied the field. Which kind of instance this is shows in
+    ``metadata_status``, not here.
     """
 
     title: Optional[str] = None
@@ -63,6 +79,46 @@ class ArxivMetadata:
     doi: Optional[str] = None
     journal: Optional[str] = None
     abstract: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MetadataFetch:
+    """The outcome of one arXiv metadata request.
+
+    Keeps the reason a request failed, which a bare ``None`` return could not.
+    The reason goes to the user. The document gets ``status``.
+
+    ``__post_init__`` accepts only what a fetch can report, meaning ``ok`` with
+    a record or ``unavailable`` with a cause.
+    """
+
+    status: str
+    metadata: Optional[ArxivMetadata] = None
+    error: Optional[str] = None
+
+    @property
+    def failure_cause(self) -> str:
+        """Why the record was not read. Defined only for a non-``ok`` outcome."""
+        if self.error is None:
+            raise ValueError("an ok outcome has no failure cause")
+        return self.error
+
+    def __post_init__(self) -> None:
+        if self.status not in _FETCH_STATUSES:
+            raise ValueError(
+                f"{self.status!r} is not a fetch outcome. "
+                f"Expected one of {_FETCH_STATUSES}"
+            )
+        if (self.status == METADATA_OK) != (self.metadata is not None):
+            raise ValueError(
+                f"status {self.status!r} disagrees with metadata="
+                f"{'present' if self.metadata is not None else 'absent'}"
+            )
+        if (self.status == METADATA_OK) != (self.error is None):
+            raise ValueError(
+                f"status {self.status!r} disagrees with error="
+                f"{'present' if self.error is not None else 'absent'}"
+            )
 
 
 def _is_yaml_printable(codepoint: int) -> bool:
@@ -120,33 +176,69 @@ def parse_version_from_id(id_url: Optional[str]) -> Optional[str]:
     """
     if not id_url:
         return None
-    path = urllib.parse.urlparse(id_url).path
+    try:
+        path = urllib.parse.urlparse(id_url).path
+    except ValueError:
+        # A malformed authority (unclosed IPv6 bracket) raises here. Fall
+        # through to the tail split, which needs no parsed path.
+        path = ""
     if path.startswith("/abs/"):
         return path[len("/abs/") :] or None
     return id_url.rsplit("/", 1)[-1] or None
 
 
-def fetch_metadata(arxiv_id: str, *, timeout: int = 10) -> Optional[ArxivMetadata]:
+def _is_error_entry(entry: ET.Element) -> bool:
+    """Whether the entry is arXiv's error report instead of a paper record.
+
+    A malformed id does not give an empty feed. arXiv answers with one entry
+    titled ``Error`` whose ``<id>`` points under ``/api/errors``, and whose
+    author and summary read like a record. The path is what this checks.
+    """
+    try:
+        path = urllib.parse.urlparse(_text(entry, "atom:id") or "").path
+    except ValueError:
+        return False
+    return path.startswith("/api/errors")
+
+
+def fetch_metadata(arxiv_id: str, *, timeout: int = 10) -> MetadataFetch:
     """Fetch the full arXiv record for ``arxiv_id`` in a single API call.
 
-    Returns ``None`` on any network or parse failure so callers can fall back
-    to a local title source (LaTeX ``\\title``, PDF embedded metadata) without
-    special-casing exceptions. Assumes ``arxiv_id`` is already validated to
-    canonical form; no zero-padding is performed here.
+    Network and parse failures land in the returned ``MetadataFetch.error``
+    instead of propagating, letting callers fall back to a local title source
+    (LaTeX ``\\title``, PDF embedded metadata) and still report the cause. Two
+    responses that parse cleanly take the same ``unavailable`` status with their
+    own ``error`` text, namely a feed with no ``<entry>`` and arXiv's error
+    report for an id it rejects.
+
+    Assumes ``arxiv_id`` is already validated to canonical form. No
+    zero-padding happens here.
     """
     url = _API_URL + "?" + urllib.parse.urlencode({"id_list": arxiv_id})
     try:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
             tree = ET.parse(resp)
-    except Exception:
-        return None
+    except Exception as exc:
+        return MetadataFetch(
+            METADATA_UNAVAILABLE,
+            error=f"{type(exc).__name__}: {exc}",
+        )
 
     entry = tree.find(".//atom:entry", _NS)
     if entry is None:
-        return None
+        return MetadataFetch(
+            METADATA_UNAVAILABLE,
+            error="arXiv returned no record for this id",
+        )
+    if _is_error_entry(entry):
+        return MetadataFetch(
+            METADATA_UNAVAILABLE,
+            error=_normalize(_text(entry, "atom:summary"))
+            or "arXiv reported an error for this id",
+        )
 
     primary = entry.find("arxiv:primary_category", _NS)
-    return ArxivMetadata(
+    meta = ArxivMetadata(
         title=_normalize(_text(entry, "atom:title")),
         authors=[
             name
@@ -168,6 +260,26 @@ def fetch_metadata(arxiv_id: str, *, timeout: int = 10) -> Optional[ArxivMetadat
         doi=_normalize(_text(entry, "arxiv:doi")),
         journal=_normalize(_text(entry, "arxiv:journal_ref")),
         abstract=_normalize(_text(entry, "atom:summary")),
+    )
+    return MetadataFetch(METADATA_OK, metadata=meta)
+
+
+def format_unavailable_warning(arxiv_id: str, *, cause: str) -> str:
+    """Compose the warning a conversion path shows when the record was unread.
+
+    Both conversion paths write null arXiv fields into a document and say the
+    same thing about them, so the whole message lives here. A step that writes
+    no such fields composes its own.
+
+    ``cause`` is the captured ``MetadataFetch.error``. Returning the text
+    instead of printing it leaves the destination to the caller.
+    """
+    return (
+        f"WARNING: could not read the arXiv record for {arxiv_id}: {cause}\n"
+        "  The arXiv-only frontmatter fields are left null. Those nulls mean "
+        "the value is unknown, not that arXiv reports none.\n"
+        "  The document's frontmatter records "
+        f"metadata_status: {METADATA_UNAVAILABLE}."
     )
 
 
@@ -239,16 +351,35 @@ def build_frontmatter(
     arxiv_id: Optional[str],
     source_type: str,
     conversion_date: str,
+    metadata_status: str,
     fallback_title: Optional[str] = None,
 ) -> str:
     """Render the YAML frontmatter block for a converted paper.
 
     Every key is always present (a total schema) so a consumer can read
-    provenance from a fixed location regardless of conversion path or whether
-    the arXiv fetch succeeded. ``arxiv_id`` is optional: manual PDF scripts
-    invoke the converter without an id, in which case it renders as null like
-    any other unknown field.
+    provenance from a fixed location whichever conversion path produced the
+    document.
+
+    ``arxiv_id`` is optional. Manual PDF scripts invoke the converter without
+    one, and it then renders as null with ``metadata_status`` ``not_requested``.
+
+    ``metadata_status`` cannot be derived from ``meta`` here. The PDF path
+    passes a record built from the PDF's own title when arXiv was unreachable,
+    which makes a non-``None`` ``meta`` compatible with every status. Both it
+    and its agreement with ``arxiv_id`` are checked at entry, because the key
+    exists to be branched on.
     """
+    if metadata_status not in METADATA_STATUSES:
+        raise ValueError(
+            f"unknown metadata_status {metadata_status!r}. "
+            f"Expected one of {METADATA_STATUSES}"
+        )
+    if (arxiv_id is None) != (metadata_status == METADATA_NOT_REQUESTED):
+        raise ValueError(
+            f"metadata_status {metadata_status!r} does not match "
+            f"arxiv_id={'absent' if arxiv_id is None else 'present'}. Without "
+            f"an id nothing can be asked of arXiv, and with one something was"
+        )
     m = meta or ArxivMetadata()
     # Normalize every emitted text scalar here, so the block is clean and valid
     # regardless of how the metadata was built — the PDF fallback path
@@ -270,6 +401,7 @@ def build_frontmatter(
         _scalar_line("doi", m.doi),
         _scalar_line("journal", m.journal),
         _scalar_line("source_type", source_type),
+        _scalar_line("metadata_status", metadata_status),
         _scalar_line("conversion_date", conversion_date),
         _block_lines("abstract", _normalize(m.abstract)),
         "---",

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
@@ -114,10 +114,13 @@ class MetadataFetch:
                 f"status {self.status!r} disagrees with metadata="
                 f"{'present' if self.metadata is not None else 'absent'}"
             )
-        if (self.status == METADATA_OK) != (self.error is None):
+        if self.status == METADATA_OK and self.error is not None:
+            raise ValueError(f"an ok outcome carries no cause, got {self.error!r}")
+        if self.status != METADATA_OK and not self.error:
+            # Checked by truthiness, not against None. The cause reaches the
+            # user verbatim, and an empty one prints a warning saying nothing.
             raise ValueError(
-                f"status {self.status!r} disagrees with error="
-                f"{'present' if self.error is not None else 'absent'}"
+                f"status {self.status!r} needs a cause, got {self.error!r}"
             )
 
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
@@ -380,8 +380,9 @@ def build_frontmatter(
     if (arxiv_id is None) != (metadata_status == METADATA_NOT_REQUESTED):
         raise ValueError(
             f"metadata_status {metadata_status!r} does not match "
-            f"arxiv_id={'absent' if arxiv_id is None else 'present'}. Without "
-            f"an id nothing can be asked of arXiv, and with one something was"
+            f"arxiv_id={'absent' if arxiv_id is None else 'present'}. "
+            f"{METADATA_NOT_REQUESTED!r} is the only status a document with no "
+            f"id can carry, and the only one a document with an id cannot"
         )
     m = meta or ArxivMetadata()
     # Normalize every emitted text scalar here, so the block is clean and valid

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/arxiv_metadata.py
@@ -116,9 +116,9 @@ class MetadataFetch:
             )
         if self.status == METADATA_OK and self.error is not None:
             raise ValueError(f"an ok outcome carries no cause, got {self.error!r}")
-        if self.status != METADATA_OK and not self.error:
-            # Checked by truthiness, not against None. The cause reaches the
-            # user verbatim, and an empty one prints a warning saying nothing.
+        if self.status != METADATA_OK and not (self.error or "").strip():
+            # Checked for content, not against None. The cause reaches the user
+            # verbatim, and a blank one prints a warning saying nothing.
             raise ValueError(
                 f"status {self.status!r} needs a cause, got {self.error!r}"
             )

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/convert_latex.py
@@ -21,12 +21,22 @@ from typing import Optional
 # arxiv_id.py isn't silently masked by the script-mode fallback.
 try:
     from arxiv_doc_builder.arxiv_id import safe_arxiv_id, validate_arxiv_id
-    from arxiv_doc_builder.arxiv_metadata import build_frontmatter, fetch_metadata
+    from arxiv_doc_builder.arxiv_metadata import (
+        METADATA_UNAVAILABLE,
+        build_frontmatter,
+        fetch_metadata,
+        format_unavailable_warning,
+    )
 except ModuleNotFoundError as _exc:
     if _exc.name != "arxiv_doc_builder":
         raise
     from arxiv_id import safe_arxiv_id, validate_arxiv_id
-    from arxiv_metadata import build_frontmatter, fetch_metadata
+    from arxiv_metadata import (
+        METADATA_UNAVAILABLE,
+        build_frontmatter,
+        fetch_metadata,
+        format_unavailable_warning,
+    )
 
 
 class AmbiguousMainTexError(Exception):
@@ -275,6 +285,10 @@ def extract_title_from_latex(tex_file: Path) -> Optional[str]:
     than picking an arbitrary file from the directory. Returns ``None`` when no
     ``\\title`` is found, so an unknown title stays null in the frontmatter
     rather than a fabricated placeholder (matching the PDF path).
+
+    Strips the markup that most often reaches the frontmatter verbatim,
+    meaning commands, braces, and the ``~`` non-breaking space. Nothing else is
+    resolved, and a title built from other constructs can still arrive mangled.
     """
     candidates = [tex_file]
     candidates += sorted(p for p in tex_file.parent.glob("*.tex") if p != tex_file)
@@ -286,6 +300,10 @@ def extract_title_from_latex(tex_file: Path) -> Optional[str]:
             title = match.group(1)
             # Clean up LaTeX commands
             title = re.sub(r"\\[a-zA-Z]+\s*", "", title)  # Remove commands
+            # ``~`` is a non-breaking space and survives the other passes,
+            # reaching the title glued between two words. The lookbehind spares
+            # ``\~``, the tilde accent.
+            title = re.sub(r"(?<!\\)~", " ", title)
             title = re.sub(r"[{}]", "", title)  # Remove braces
             title = re.sub(r"\s+", " ", title).strip()  # Normalize whitespace
             return title or None
@@ -303,7 +321,13 @@ def post_process_markdown(md_file: Path, arxiv_id: str, tex_file: Path):
     # when the arXiv fetch did not provide one (offline / not found). Extracting
     # it lazily avoids a needless file read on the common path. conversion_date
     # is UTC-aware so the provenance stamp is unambiguous across environments.
-    meta = fetch_metadata(arxiv_id)
+    fetched = fetch_metadata(arxiv_id)
+    meta = fetched.metadata
+    if fetched.status == METADATA_UNAVAILABLE:
+        print(
+            format_unavailable_warning(arxiv_id, cause=fetched.failure_cause),
+            file=sys.stderr,
+        )
     fallback_title = None
     if meta is None or not meta.title:
         fallback_title = extract_title_from_latex(tex_file)
@@ -312,6 +336,7 @@ def post_process_markdown(md_file: Path, arxiv_id: str, tex_file: Path):
         arxiv_id=arxiv_id,
         source_type="latex",
         conversion_date=datetime.now(timezone.utc).isoformat(),
+        metadata_status=fetched.status,
         fallback_title=fallback_title,
     )
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/fetch_paper.py
@@ -20,36 +20,42 @@ from typing import Optional
 # fallback — only a genuinely absent top-level package falls through.
 try:
     from arxiv_doc_builder.arxiv_id import safe_arxiv_id, validate_arxiv_id
-    from arxiv_doc_builder.arxiv_metadata import fetch_metadata
+    from arxiv_doc_builder.arxiv_metadata import MetadataFetch, fetch_metadata
 except ModuleNotFoundError as _exc:
     if _exc.name != "arxiv_doc_builder":
         raise
     # Script invocation: script dir is on sys.path[0], so arxiv_id.py is
     # importable as a top-level module.
     from arxiv_id import safe_arxiv_id, validate_arxiv_id
-    from arxiv_metadata import fetch_metadata
+    from arxiv_metadata import MetadataFetch, fetch_metadata
 
 
 _METADATA_FILE = ".arxiv-fetch.json"
 
 
-def _get_latest_version(arxiv_id: str) -> Optional[str]:
-    """Query the arXiv API for the latest version string.
+def _probe_metadata(arxiv_id: str) -> MetadataFetch:
+    """Query the arXiv API for the record the drift check reads.
 
-    Returns e.g. ``"2409.03108v2"`` on success, or ``None`` on any
-    failure (network error, parse error, offline). ``None`` signals
-    that callers should trust the cache.
+    Returns the whole outcome, not just a version string. An unreachable API
+    and a record without a version tail both leave the sidecar unwritten, and
+    only the outcome tells them apart.
 
-    Delegates to the shared ``fetch_metadata`` so the Atom request/parse
-    idiom lives in one place; the returned ``version`` is the full versioned
-    tail this drift check persists to the sidecar unchanged. A short timeout
-    keeps the pre-fetch probe lightweight.
+    Delegates to ``fetch_metadata`` for the Atom request. ``_latest_version``
+    reads the version out. A short timeout keeps the pre-fetch probe light.
 
-    Assumes ``arxiv_id`` has already been validated to canonical form
-    by ``validate_arxiv_id``; no zero-padding is performed here.
+    Assumes ``arxiv_id`` has already been validated to canonical form by
+    ``validate_arxiv_id``. No zero-padding happens here.
     """
-    meta = fetch_metadata(arxiv_id, timeout=5)
-    return meta.version if meta else None
+    return fetch_metadata(arxiv_id, timeout=5)
+
+
+def _latest_version(probe: MetadataFetch) -> Optional[str]:
+    """The version string the probe reports, or ``None`` when it reports none.
+
+    The rest of this module reads ``None`` as "no usable answer from the API",
+    whether the request failed or the record carried no version tail.
+    """
+    return probe.metadata.version if probe.metadata else None
 
 
 def _read_cached_version(paper_dir: Path) -> Optional[str]:
@@ -62,6 +68,44 @@ def _read_cached_version(paper_dir: Path) -> Optional[str]:
         return data.get("version")
     except Exception:
         return None
+
+
+def _record_version(paper_dir: Path, latest: Optional[str], *, fetched: bool) -> bool:
+    """Persist the fetched version, reporting whether it was persisted.
+
+    Writes only with a version *and* material. Recording a version for an empty
+    paper directory would misrepresent it. Returns ``False`` having written
+    nothing otherwise.
+    """
+    if latest is None or not fetched:
+        return False
+    _write_cached_version(paper_dir, latest)
+    return True
+
+
+def _format_sidecar_skip_warning(arxiv_id: str, probe: MetadataFetch) -> str:
+    """The warning for a run that fetched material but recorded no version.
+
+    Composed here, not through the conversion paths' shared warning. This step
+    writes no frontmatter and has no null fields to explain, and it fires on a
+    probe that may have succeeded.
+
+    Call only when ``_record_version`` returned ``False`` for a run that did
+    obtain material.
+    """
+    if _latest_version(probe) is not None:
+        raise ValueError(
+            "the probe reported a version, so the sidecar was not skipped for "
+            "the reason this warning states"
+        )
+    if probe.error is not None:
+        situation = f"could not read the arXiv record for {arxiv_id}: {probe.error}"
+    else:
+        situation = f"the arXiv record for {arxiv_id} carried no version"
+    return (
+        f"WARNING: {situation}\n"
+        f"  Version drift was not checked, and {_METADATA_FILE} was not updated."
+    )
 
 
 def _write_cached_version(paper_dir: Path, version: str) -> None:
@@ -329,7 +373,8 @@ def main():
     print()
 
     # Check for version drift before fetching
-    latest = _get_latest_version(args.arxiv_id)
+    probe = _probe_metadata(args.arxiv_id)
+    latest = _latest_version(probe)
     refresh = _needs_refresh(paper_dir, latest)
     if refresh:
         cached = _read_cached_version(paper_dir)
@@ -355,8 +400,9 @@ def main():
     )
 
     # Record version after successful fetch
-    if latest is not None and (has_source or has_pdf):
-        _write_cached_version(paper_dir, latest)
+    fetched_any = has_source or has_pdf
+    if not _record_version(paper_dir, latest, fetched=fetched_any) and fetched_any:
+        print(_format_sidecar_skip_warning(args.arxiv_id, probe), file=sys.stderr)
 
     # Summary
     print()
@@ -366,7 +412,7 @@ def main():
     if has_pdf:
         print("✓ PDF available")
 
-    if not (has_source or has_pdf):
+    if not fetched_any:
         print("✗ Failed to fetch any materials")
         sys.exit(1)
 

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
@@ -319,10 +319,6 @@ def convert_pdf_to_markdown(
                     file=sys.stderr,
                 )
         else:
-            # No id was supplied, so nothing was asked of arXiv and there is no
-            # outage to report. The status still has to say so: without it a
-            # reader could not tell this document's null arXiv fields from ones
-            # left null by a failed request.
             metadata_status = METADATA_NOT_REQUESTED
             meta = None
         if meta is None:

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
@@ -5,6 +5,7 @@ Shared library for PDF to Markdown conversion.
 This module provides common functions used by the PDF converter scripts.
 """
 
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Set
@@ -17,14 +18,24 @@ from pypdf import PdfReader
 # masked. arxiv_metadata is stdlib-only, so it imports under the uv env too.
 try:
     from arxiv_doc_builder.arxiv_metadata import (
+        METADATA_NOT_REQUESTED,
+        METADATA_UNAVAILABLE,
         ArxivMetadata,
         build_frontmatter,
         fetch_metadata,
+        format_unavailable_warning,
     )
 except ModuleNotFoundError as _exc:
     if _exc.name != "arxiv_doc_builder":
         raise
-    from arxiv_metadata import ArxivMetadata, build_frontmatter, fetch_metadata
+    from arxiv_metadata import (
+        METADATA_NOT_REQUESTED,
+        METADATA_UNAVAILABLE,
+        ArxivMetadata,
+        build_frontmatter,
+        fetch_metadata,
+        format_unavailable_warning,
+    )
 
 
 def parse_page_ranges(range_str: Optional[str]) -> Set[int]:
@@ -258,10 +269,17 @@ def convert_pdf_to_markdown(
         arxiv_id: arXiv ID for authoritative metadata. When given, the arXiv
             record drives the frontmatter; when omitted (manual PDF scripts) or
             the fetch fails, the PDF's embedded title/author are used and the
-            arXiv-only fields render as null.
+            arXiv-only fields render as null. ``metadata_status`` records
+            which of the three happened.
     """
     if double_column_pages is None:
         double_column_pages = set()
+    # One notion of "no id" for the whole function. The status branch below
+    # tests truthiness while the frontmatter builder tests for None, so an
+    # empty string would take the no-id branch here and then be rejected there
+    # for disagreeing with the status it produced, aborting a conversion over
+    # an id that is merely absent.
+    arxiv_id = arxiv_id or None
 
     print(f"Converting PDF: {pdf_path}")
     print(f"Output: {output_path}")
@@ -291,7 +309,22 @@ def convert_pdf_to_markdown(
         # back to the PDF's embedded title/author, leaving arXiv-only fields
         # null. The old bold "Source/Converted/Pages" header is intentionally
         # dropped in favour of this single provenance surface.
-        meta = fetch_metadata(arxiv_id) if arxiv_id else None
+        if arxiv_id:
+            fetched = fetch_metadata(arxiv_id)
+            metadata_status = fetched.status
+            meta = fetched.metadata
+            if metadata_status == METADATA_UNAVAILABLE:
+                print(
+                    format_unavailable_warning(arxiv_id, cause=fetched.failure_cause),
+                    file=sys.stderr,
+                )
+        else:
+            # No id was supplied, so nothing was asked of arXiv and there is no
+            # outage to report. The status still has to say so: without it a
+            # reader could not tell this document's null arXiv fields from ones
+            # left null by a failed request.
+            metadata_status = METADATA_NOT_REQUESTED
+            meta = None
         if meta is None:
             pdf_author = metadata["author"]
             meta = ArxivMetadata(
@@ -304,6 +337,7 @@ def convert_pdf_to_markdown(
             source_type="pdf",
             # UTC-aware so the provenance stamp is unambiguous across environments.
             conversion_date=datetime.now(timezone.utc).isoformat(),
+            metadata_status=metadata_status,
             fallback_title=metadata["title"],
         )
         markdown_parts.append(header)

--- a/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
+++ b/skills/arxiv-doc-builder/arxiv_doc_builder/pdf_converter_lib.py
@@ -270,7 +270,7 @@ def convert_pdf_to_markdown(
             record drives the frontmatter; when omitted (manual PDF scripts) or
             the fetch fails, the PDF's embedded title/author are used and the
             arXiv-only fields render as null. ``metadata_status`` records
-            which of the three happened.
+            which of those happened.
     """
     if double_column_pages is None:
         double_column_pages = set()

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -65,14 +65,12 @@ Field notes:
 - `doi` / `journal` are whatever arXiv's own record carries. Resolving a DOI
   that arXiv does not carry (e.g. via OpenAlex) is the arxiv-lookup skill's job,
   not this converter's.
-- When no arXiv record backs the document the schema still holds, and two
-  fields are filled from local sources instead. `title` comes from the LaTeX
-  `\title` or the PDF's embedded title on either path. `authors` comes from the
-  PDF's embedded author on the PDF path, and stays null on the LaTeX path.
-  Every other arXiv-sourced field renders as null.
-- A populated `title` or `authors` is therefore no evidence that arXiv was
-  reached. `metadata_status` is what answers that, carrying `unavailable` when
-  the record could not be read and `not_requested` when no id was supplied.
+- Two fields survive on local sources when no arXiv record backs the document.
+  `title` comes from the LaTeX `\title` or the PDF's embedded title on either
+  path, and `authors` from the PDF's embedded author on the PDF path, staying
+  null on the LaTeX path. Every other arXiv-sourced field renders as null.
+  A populated `title` or `authors` is therefore no evidence that arXiv was
+  reached, and `metadata_status` is what answers that.
 
 ## Body Structure
 
@@ -229,9 +227,9 @@ papers/
 The provenance metadata lives in the document's YAML frontmatter (see above).
 `.arxiv-fetch.json` is an internal sidecar used only for version-drift
 detection (`{"version": "2409.03108v2"}`); it is not the metadata surface a
-consumer reads. It is written only when the fetch obtained material *and* the
-arXiv record supplied a version. Two situations leave it absent or holding an
-older value, namely a record that could not be read and a record read without a
-version. A fetch that obtained material in either situation prints the reason on
-stderr, because it otherwise looks like an ordinary success. A fetch that
-obtained no material at all exits non-zero on its own.
+consumer reads.
+
+The sidecar records a version only when the fetch obtained material and the
+arXiv record supplied one. A run that obtained material without a version
+leaves the sidecar as it found it and says so on stderr. A run that obtained no
+material at all exits non-zero.

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -24,14 +24,15 @@ record behind the arXiv-derived fields was read:
 - `ok`. The record was read, and a null field is a **confirmed absence**. arXiv
   holds this paper's record and reports no value there, which supports a
   "preprint, no journal DOI" reading.
-- `unavailable`. The record was not read, because the request failed, because
-  arXiv returned no record for the id, or because arXiv rejected the id. A null
-  field is **unknown**, not confirmed. The conversion prints which of the three
-  on stderr as it runs.
-- `not_requested`. No arXiv id was supplied, and nothing was asked of arXiv. A
-  null field is likewise unknown. This reports an absent question, not a
-  failure. Of the manual PDF conversion scripts only `convert_pdf_simple.py`
-  accepts an `--arxiv-id`, and documents from the others always carry this
+- `unavailable`. The request failed, arXiv returned no record for the id, or
+  arXiv rejected the id. The converter saw a record in none of the three, which
+  leaves a null field **unknown** instead of a confirmed absence. The conversion
+  names the cause on stderr as it runs.
+- `not_requested`. The conversion ran with no arXiv id, and the record was
+  never sought. A null field is unknown here as well, for a different reason
+  than under `unavailable`, where the question was put and no record came back.
+  Among the manual PDF conversion scripts, `convert_pdf_simple.py` is the one
+  that takes an `--arxiv-id`, and documents from the rest always carry this
   token.
 
 ```yaml

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -15,9 +15,24 @@ This document has two kinds of content:
 
 `build_frontmatter` writes one YAML block keyed identically on both conversion
 paths (LaTeX and PDF). The schema is **total**: every key is always present.
-A value that arXiv does not report renders as YAML null (a bare `key:`), which
-a parser reads as `None` — distinguishing "arXiv reported no value" (e.g. a
-preprint with no journal DOI) from a key that was never written.
+A value that is not known renders as YAML null (a bare `key:`), which a parser
+reads as `None` and not as a missing key.
+
+What a null means depends on `metadata_status`, which records whether the arXiv
+record behind the arXiv-derived fields was read:
+
+- `ok`. The record was read, and a null field is a **confirmed absence**. arXiv
+  holds this paper's record and reports no value there, which supports a
+  "preprint, no journal DOI" reading.
+- `unavailable`. The record was not read, because the request failed, because
+  arXiv returned no record for the id, or because arXiv rejected the id. A null
+  field is **unknown**, not confirmed. The conversion prints which of the three
+  on stderr as it runs.
+- `not_requested`. No arXiv id was supplied, and nothing was asked of arXiv. A
+  null field is likewise unknown. This reports an absent question, not a
+  failure. Of the manual PDF conversion scripts only `convert_pdf_simple.py`
+  accepts an `--arxiv-id`, and documents from the others always carry this
+  token.
 
 ```yaml
 ---
@@ -30,9 +45,10 @@ primary_category: "cs.AI"
 categories:
   - "cs.AI"
   - "cs.CL"
-doi: "10.1145/1234567.1234568"   # or bare `doi:` (null) when arXiv reports none
+doi: "10.1145/1234567.1234568"   # or bare `doi:` (null); see metadata_status
 journal: "Proc. ACM, 2024"       # or bare `journal:` (null)
 source_type: "latex"             # or "pdf"
+metadata_status: "ok"            # or "unavailable" / "not_requested"
 conversion_date: "2025-12-08T10:00:00+00:00"
 abstract: |-
   Single-paragraph abstract, whitespace-normalized.
@@ -48,10 +64,14 @@ Field notes:
 - `doi` / `journal` are whatever arXiv's own record carries. Resolving a DOI
   that arXiv does not carry (e.g. via OpenAlex) is the arxiv-lookup skill's job,
   not this converter's.
-- When the arXiv fetch fails (offline), the schema still holds: `title` falls
-  back to the LaTeX `\title` or the PDF's embedded title, and the arXiv-only
-  fields render as null. Manual PDF scripts invoked without an id likewise get
-  a valid block with `arxiv_id:` null.
+- When no arXiv record backs the document the schema still holds, and two
+  fields are filled from local sources instead. `title` comes from the LaTeX
+  `\title` or the PDF's embedded title on either path. `authors` comes from the
+  PDF's embedded author on the PDF path, and stays null on the LaTeX path.
+  Every other arXiv-sourced field renders as null.
+- A populated `title` or `authors` is therefore no evidence that arXiv was
+  reached. `metadata_status` is what answers that, carrying `unavailable` when
+  the record could not be read and `not_requested` when no id was supplied.
 
 ## Body Structure
 
@@ -208,4 +228,9 @@ papers/
 The provenance metadata lives in the document's YAML frontmatter (see above).
 `.arxiv-fetch.json` is an internal sidecar used only for version-drift
 detection (`{"version": "2409.03108v2"}`); it is not the metadata surface a
-consumer reads.
+consumer reads. It is written only when the fetch obtained material *and* the
+arXiv record supplied a version. Two situations leave it absent or holding an
+older value, namely a record that could not be read and a record read without a
+version. A fetch that obtained material in either situation prints the reason on
+stderr, because it otherwise looks like an ordinary success. A fetch that
+obtained no material at all exits non-zero on its own.

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -25,9 +25,9 @@ record behind the arXiv-derived fields was read:
   holds this paper's record and reports no value there, which supports a
   "preprint, no journal DOI" reading.
 - `unavailable`. The request failed, arXiv returned no record for the id, or
-  arXiv rejected the id. The converter saw a record in none of the three, which
-  leaves a null field **unknown** instead of a confirmed absence. The conversion
-  names the cause on stderr as it runs.
+  arXiv rejected the id. No record reached the converter, which leaves a null
+  field **unknown** instead of a confirmed absence. The conversion names the
+  cause on stderr as it runs.
 - `not_requested`. The conversion ran with no arXiv id, and the record was
   never sought. A null field is unknown here as well, for a different reason
   than under `unavailable`, where the question was put and no record came back.

--- a/skills/arxiv-doc-builder/references/output-format.md
+++ b/skills/arxiv-doc-builder/references/output-format.md
@@ -231,5 +231,5 @@ consumer reads.
 
 The sidecar records a version only when the fetch obtained material and the
 arXiv record supplied one. A run that obtained material without a version
-leaves the sidecar as it found it and says so on stderr. A run that obtained no
-material at all exits non-zero.
+writes nothing to it, leaving any earlier value in place, and says so on
+stderr. A run that obtained no material at all exits non-zero.

--- a/skills/arxiv-doc-builder/tests/conftest.py
+++ b/skills/arxiv-doc-builder/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Metadata-probe outcomes shared by the modules that need one as an input.
+
+`test_arxiv_metadata.py` builds its own, because it tests how `MetadataFetch`
+is constructed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from arxiv_doc_builder.arxiv_metadata import (
+    METADATA_OK,
+    METADATA_UNAVAILABLE,
+    ArxivMetadata,
+    MetadataFetch,
+)
+
+PROBE_ERROR = "OSError: connection reset"
+PROBE_VERSION = "2409.03108v2"
+
+
+@pytest.fixture
+def failed_probe() -> MetadataFetch:
+    """A request that never reached a record."""
+    return MetadataFetch(METADATA_UNAVAILABLE, error=PROBE_ERROR)
+
+
+@pytest.fixture
+def probe_with_version() -> MetadataFetch:
+    """A record that was read and carries a version tail."""
+    return MetadataFetch(METADATA_OK, metadata=ArxivMetadata(version=PROBE_VERSION))
+
+
+@pytest.fixture
+def probe_without_version() -> MetadataFetch:
+    """A record that was read but carries no version tail.
+
+    The cell that separates "the request failed" from "no version to record":
+    both leave the sidecar unwritten, by different routes.
+    """
+    return MetadataFetch(METADATA_OK, metadata=ArxivMetadata(version=None))
+
+
+@pytest.fixture
+def patch_fetch(monkeypatch):
+    """Point a module's ``fetch_metadata`` at a fixed outcome.
+
+    Each caller-level test replaces the same name in one module or the other,
+    so the module is the only thing that varies.
+    """
+
+    def install(module, probe: MetadataFetch) -> None:
+        monkeypatch.setattr(module, "fetch_metadata", lambda _id: probe)
+
+    return install
+
+
+def status_of(document: Path) -> str:
+    """The ``metadata_status`` value the document's frontmatter carries."""
+    for line in document.read_text(encoding="utf-8").splitlines():
+        if line.startswith("metadata_status:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    raise AssertionError(f"no metadata_status line in {document}")

--- a/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
@@ -333,6 +333,7 @@ def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
         {"status": METADATA_OK},
         {"status": METADATA_OK, "metadata": ArxivMetadata(), "error": "e"},
         {"status": METADATA_UNAVAILABLE},
+        {"status": METADATA_UNAVAILABLE, "error": ""},
         {"status": METADATA_UNAVAILABLE, "metadata": ArxivMetadata(), "error": "e"},
     ],
     ids=[
@@ -341,6 +342,7 @@ def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
         "ok-without-record",
         "ok-with-error",
         "failed-without-cause",
+        "failed-with-empty-cause",
         "failed-with-record",
     ],
 )

--- a/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
@@ -315,9 +315,8 @@ def test_fetch_reports_a_parse_failure_as_unavailable(transport):
 
 
 def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
-    # A parseable response carrying no record leaves the caller exactly as
-    # uninformed as an outage does, and takes the same status. Its own cause
-    # text is what tells the two apart in the warning.
+    # Same status as an outage, since the caller learns as little either way.
+    # The cause text is what tells the two apart.
     transport(_ATOM_NO_ENTRY)
     result = fetch_metadata("2606.09995")
     assert result.status == METADATA_UNAVAILABLE
@@ -349,9 +348,6 @@ def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
     ],
 )
 def test_incoherent_fetch_outcomes_are_rejected(kwargs):
-    # One caller branches on the status, another on the record. If the two can
-    # disagree, those callers can disagree. The combination is refused at
-    # construction.
     with pytest.raises(ValueError):
         MetadataFetch(**kwargs)
 
@@ -360,8 +356,7 @@ def test_warning_names_the_paper_the_cause_and_what_the_document_records():
     text = format_unavailable_warning("2606.09995", cause="OSError: connection reset")
     assert "2606.09995" in text
     assert "OSError: connection reset" in text
-    # The sentence that stops a reader treating the nulls as confirmed
-    # absences, and the token the document carries so a machine can tell.
+    # A human reads "unknown", a machine reads the token.
     assert "unknown" in text
     assert METADATA_UNAVAILABLE in text
 
@@ -379,19 +374,18 @@ def test_warning_names_the_paper_the_cause_and_what_the_document_records():
     ids=list(METADATA_STATUSES),
 )
 def test_every_status_token_round_trips_into_the_document(status, arxiv_id):
-    # Each token is paired with the id state that can produce it, since the
-    # guard rejects the other pairings and a single id would not do. Spelling
-    # the cases out while taking the ids from METADATA_STATUSES is deliberate:
-    # a token added there and not here changes the id count only, which pytest
-    # rejects at collection.
+    # Each token needs the id state that can produce it. The guard rejects
+    # every other pairing. Taking the ids from METADATA_STATUSES while
+    # spelling the cases out means a token added there and not here leaves the
+    # two lengths unequal, and pytest fails at collection.
     parsed = _parse(_fm(_FULL, arxiv_id=arxiv_id, metadata_status=status))
     assert parsed["metadata_status"] == status
     assert set(parsed.keys()) == FRONTMATTER_KEYS
 
 
 def test_unknown_status_token_is_rejected_rather_than_rendered():
-    # The key exists to be branched on, so an unrecognized token would read as
-    # one more unknown state instead of as the typo it is.
+    # A consumer branches on this key. An unrecognized token would render as
+    # one more state to handle.
     with pytest.raises(ValueError):
         _fm(_FULL, metadata_status="degraded")
 
@@ -441,8 +435,8 @@ def test_a_document_with_no_arxiv_id_cannot_claim_a_record_was_sought(status):
 
 
 def test_a_document_with_an_arxiv_id_cannot_claim_none_was_sought():
-    # The converse, and why the guard is an equivalence. An id was supplied,
-    # something was asked of arXiv, and the answer is ok or unavailable.
+    # This is the converse the equivalence adds. An id was supplied, arXiv was
+    # asked, and the answer is either ok or unavailable.
     with pytest.raises(ValueError):
         _fm(_FULL, arxiv_id="2606.09995", metadata_status=METADATA_NOT_REQUESTED)
 
@@ -460,10 +454,10 @@ _ATOM_ERROR_ENTRY = b"""<?xml version="1.0" encoding="UTF-8"?>
 
 
 def test_fetch_reports_an_arxiv_error_report_as_unavailable(transport):
-    # A rejected id does not give an empty feed. arXiv answers with an entry
-    # that parses like a record, and taking it at face value would write
-    # title "Error" and author "arXiv api core" into the document under
-    # metadata_status "ok", where a null field reads as a confirmed absence.
+    # arXiv answers a rejected id with an entry, not with an empty feed, and
+    # that entry parses like a record. Taken at face value it writes title
+    # "Error" and author "arXiv api core" into a document reporting ok, where
+    # a null field reads as a confirmed absence.
     transport(_ATOM_ERROR_ENTRY)
     result = fetch_metadata("2409.3108")
     assert result.status == METADATA_UNAVAILABLE
@@ -491,8 +485,9 @@ _ATOM_UNPARSEABLE_ID = b"""<?xml version="1.0" encoding="UTF-8"?>
 
 
 def test_fetch_names_a_cause_when_the_error_entry_carries_no_summary(transport):
-    # The cause reaches the user verbatim, so an empty one would print a
-    # warning that says nothing about why.
+    # The warning prints the cause verbatim. An error entry can arrive without
+    # a summary, and the fallback literal is what keeps that line from being
+    # blank.
     transport(_ATOM_ERROR_WITHOUT_SUMMARY)
     result = fetch_metadata("2409.3108")
     assert result.status == METADATA_UNAVAILABLE

--- a/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
@@ -2,17 +2,31 @@
 
 The frontmatter is the provenance surface a downstream consumer reads, so the
 schema must be total (every key always present) and the emitted text must be
-valid, re-parseable YAML — including the absence-confirmation contract where a
-missing arXiv value renders as YAML null rather than an absent key.
+valid, re-parseable YAML, including the absence-confirmation contract where a
+missing arXiv value renders as YAML null instead of an absent key. That null
+confirms an absence only under ``metadata_status: ok``. Under the other tokens
+the record was never read and the same null reports ignorance, which is why the
+tests below pin the status alongside the fields it qualifies.
 
 The round-trip assertions use PyYAML (a test-only dependency) as an independent
 oracle; ``importorskip`` keeps the suite green in a bare environment without it,
 while the structural assertions below pin the contract with no dependency.
 """
 
+from typing import Optional
+
+import pytest
+
 from arxiv_doc_builder.arxiv_metadata import (
+    METADATA_NOT_REQUESTED,
+    METADATA_OK,
+    METADATA_STATUSES,
+    METADATA_UNAVAILABLE,
     ArxivMetadata,
+    MetadataFetch,
     build_frontmatter,
+    fetch_metadata,
+    format_unavailable_warning,
     parse_version_from_id,
 )
 
@@ -28,6 +42,7 @@ FRONTMATTER_KEYS = {
     "doi",
     "journal",
     "source_type",
+    "metadata_status",
     "conversion_date",
     "abstract",
 }
@@ -45,6 +60,19 @@ _FULL = ArxivMetadata(
 )
 
 
+def _fm(meta: Optional[ArxivMetadata] = None, **kwargs) -> str:
+    """``build_frontmatter`` with the provenance arguments defaulted.
+
+    Every call needs an id, a source type, a date and a status. Defaulting them
+    keeps each test's arguments down to what it asserts about.
+    """
+    kwargs.setdefault("arxiv_id", "2606.09995")
+    kwargs.setdefault("source_type", "latex")
+    kwargs.setdefault("conversion_date", "d")
+    kwargs.setdefault("metadata_status", METADATA_OK)
+    return build_frontmatter(meta, **kwargs)
+
+
 def _parse(frontmatter: str):
     """Parse the inner YAML of a ``---``-fenced frontmatter block via PyYAML."""
     import pytest
@@ -58,12 +86,7 @@ def _parse(frontmatter: str):
 
 
 def test_all_keys_present_in_full_metadata():
-    fm = build_frontmatter(
-        _FULL,
-        arxiv_id="2606.09995",
-        source_type="latex",
-        conversion_date="2026-06-11T10:00:00",
-    )
+    fm = _fm(_FULL, conversion_date="2026-06-11T10:00:00")
     for key in FRONTMATTER_KEYS:
         assert f"{key}:" in fm, f"missing key {key!r} in frontmatter"
     assert fm.startswith("---\n")
@@ -75,9 +98,7 @@ def test_absent_doi_journal_render_as_bare_null_keys():
     # `doi:` (null), distinct from omitting the key. A bare `key:` line, not
     # `key: ""`, is what a parser reads as None.
     meta = ArxivMetadata(title="T", doi=None, journal=None)
-    fm = build_frontmatter(
-        meta, arxiv_id="2606.09995", source_type="latex", conversion_date="d"
-    )
+    fm = _fm(meta)
     assert "\ndoi:\n" in fm
     assert "\njournal:\n" in fm
     assert 'doi: ""' not in fm
@@ -85,11 +106,11 @@ def test_absent_doi_journal_render_as_bare_null_keys():
 
 def test_absent_arxiv_id_renders_as_null():
     # Manual PDF scripts invoke the converter without an id.
-    fm = build_frontmatter(
+    fm = _fm(
         None,
         arxiv_id=None,
         source_type="pdf",
-        conversion_date="d",
+        metadata_status=METADATA_NOT_REQUESTED,
         fallback_title="From PDF",
     )
     assert "\narxiv_id:\n" in fm
@@ -100,12 +121,7 @@ def test_absent_arxiv_id_renders_as_null():
 
 
 def test_full_metadata_round_trips():
-    fm = build_frontmatter(
-        _FULL,
-        arxiv_id="2606.09995",
-        source_type="latex",
-        conversion_date="2026-06-11T10:00:00",
-    )
+    fm = _fm(_FULL, conversion_date="2026-06-11T10:00:00")
     parsed = _parse(fm)
 
     assert set(parsed.keys()) == FRONTMATTER_KEYS
@@ -127,11 +143,7 @@ def test_full_metadata_round_trips():
 
 def test_absent_fields_parse_to_none():
     meta = ArxivMetadata(title="T", doi=None, journal=None, abstract=None)
-    parsed = _parse(
-        build_frontmatter(
-            meta, arxiv_id="2606.09995", source_type="latex", conversion_date="d"
-        )
-    )
+    parsed = _parse(_fm(meta))
     assert "doi" in parsed and parsed["doi"] is None
     assert "journal" in parsed and parsed["journal"] is None
     assert "abstract" in parsed and parsed["abstract"] is None
@@ -143,7 +155,12 @@ def test_no_metadata_keeps_title_null_not_fabricated():
     # A PDF with no embedded title and no arXiv id keeps the title null rather
     # than fabricating one from the file name — "unknown stays unknown".
     parsed = _parse(
-        build_frontmatter(None, arxiv_id=None, source_type="pdf", conversion_date="d")
+        _fm(
+            None,
+            arxiv_id=None,
+            source_type="pdf",
+            metadata_status=METADATA_NOT_REQUESTED,
+        )
     )
     assert parsed["title"] is None
     assert parsed["authors"] is None
@@ -153,11 +170,9 @@ def test_no_metadata_keeps_title_null_not_fabricated():
 
 def test_offline_metadata_keeps_total_schema_with_fallback_title():
     parsed = _parse(
-        build_frontmatter(
+        _fm(
             None,
-            arxiv_id="2606.09995",
-            source_type="latex",
-            conversion_date="d",
+            metadata_status=METADATA_UNAVAILABLE,
             fallback_title="LaTeX Title",
         )
     )
@@ -169,9 +184,7 @@ def test_offline_metadata_keeps_total_schema_with_fallback_title():
 
 def test_tricky_title_round_trips():
     meta = ArxivMetadata(title='Tricky: "quotes", colon: and \\backslash')
-    parsed = _parse(
-        build_frontmatter(meta, arxiv_id="x", source_type="latex", conversion_date="d")
-    )
+    parsed = _parse(_fm(meta, arxiv_id="x"))
     assert parsed["title"] == 'Tricky: "quotes", colon: and \\backslash'
 
 
@@ -181,9 +194,7 @@ def test_pdf_style_raw_author_with_newline_stays_valid_yaml():
     # newline (common in malformed PDF /Author fields) must not corrupt the
     # YAML; build_frontmatter normalizes it to a single line.
     meta = ArxivMetadata(title="T", authors=["Jane Doe\n--- affiliation"])
-    parsed = _parse(
-        build_frontmatter(meta, arxiv_id="x", source_type="pdf", conversion_date="d")
-    )
+    parsed = _parse(_fm(meta, arxiv_id="x", source_type="pdf"))
     assert parsed["authors"] == "Jane Doe --- affiliation"
 
 
@@ -200,9 +211,7 @@ def test_non_printable_characters_are_stripped_and_yaml_stays_valid():
         authors=["Jo" + controls + "hn"],
         abstract="Clean" + controls + "Abstract",
     )
-    parsed = _parse(
-        build_frontmatter(meta, arxiv_id="x", source_type="pdf", conversion_date="d")
-    )
+    parsed = _parse(_fm(meta, arxiv_id="x", source_type="pdf"))
     assert parsed["title"] == "AB"
     assert parsed["authors"] == "John"
     assert parsed["abstract"] == "CleanAbstract"
@@ -227,3 +236,272 @@ def test_parse_version_legacy_full_tail():
 def test_parse_version_empty_and_none():
     assert parse_version_from_id("") is None
     assert parse_version_from_id(None) is None
+
+
+# --- fetch outcome: status, cause, and what each one licenses ---------------
+
+_ATOM_ENTRY = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:arxiv="http://arxiv.org/schemas/atom">
+  <entry>
+    <id>http://arxiv.org/abs/2606.09995v1</id>
+    <title>A Study of Things</title>
+    <published>2026-06-08T00:00:00Z</published>
+    <summary>An abstract.</summary>
+    <author><name>Chiara Capecci</name></author>
+    <arxiv:primary_category term="quant-ph"/>
+    <category term="quant-ph"/>
+    <arxiv:doi>10.1103/PhysRevD.76.013009</arxiv:doi>
+  </entry>
+</feed>
+"""
+
+_ATOM_NO_ENTRY = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"></feed>
+"""
+
+
+@pytest.fixture
+def transport(monkeypatch):
+    """Replace the HTTP transport so no test reaches arXiv.
+
+    Yields a setter taking either bytes (the body ``fetch_metadata`` will
+    parse) or an exception instance (raised in place of the request).
+    """
+    import io
+
+    import arxiv_doc_builder.arxiv_metadata as m
+
+    def install(outcome):
+        def fake_urlopen(url, timeout=None):
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return io.BytesIO(outcome)
+
+        monkeypatch.setattr(m.urllib.request, "urlopen", fake_urlopen)
+
+    return install
+
+
+def test_fetch_reports_ok_and_the_record_when_the_request_succeeds(transport):
+    transport(_ATOM_ENTRY)
+    result = fetch_metadata("2606.09995")
+    assert result.status == METADATA_OK
+    assert result.error is None
+    assert result.metadata is not None
+    assert result.metadata.title == "A Study of Things"
+    assert result.metadata.version == "2606.09995v1"
+
+
+def test_fetch_reports_the_transport_failure_rather_than_discarding_it(transport):
+    # The captured cause is the whole point: without it the warning could say
+    # only that something went wrong, which does not distinguish an outage from
+    # a rate limit from a bad id.
+    transport(OSError("connection reset"))
+    result = fetch_metadata("2606.09995")
+    assert result.status == METADATA_UNAVAILABLE
+    assert result.metadata is None
+    assert result.error is not None
+    assert "OSError" in result.error
+    assert "connection reset" in result.error
+
+
+def test_fetch_reports_a_parse_failure_as_unavailable(transport):
+    transport(b"<feed>not closed")
+    result = fetch_metadata("2606.09995")
+    assert result.status == METADATA_UNAVAILABLE
+    assert result.metadata is None
+    assert result.error
+
+
+def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
+    # A parseable response carrying no record leaves the caller exactly as
+    # uninformed as an outage does, and takes the same status. Its own cause
+    # text is what tells the two apart in the warning.
+    transport(_ATOM_NO_ENTRY)
+    result = fetch_metadata("2606.09995")
+    assert result.status == METADATA_UNAVAILABLE
+    assert result.metadata is None
+    assert result.error == "arXiv returned no record for this id"
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"status": "bogus"},
+        {"status": METADATA_NOT_REQUESTED, "error": "e"},
+        {"status": METADATA_OK},
+        {"status": METADATA_OK, "metadata": ArxivMetadata(), "error": "e"},
+        {"status": METADATA_UNAVAILABLE},
+        {"status": METADATA_UNAVAILABLE, "metadata": ArxivMetadata(), "error": "e"},
+    ],
+    ids=[
+        "unknown-token",
+        "not-a-fetch-outcome",
+        "ok-without-record",
+        "ok-with-error",
+        "failed-without-cause",
+        "failed-with-record",
+    ],
+)
+def test_incoherent_fetch_outcomes_are_rejected(kwargs):
+    # One caller branches on the status, another on the record. If the two can
+    # disagree, those callers can disagree. The combination is refused at
+    # construction.
+    with pytest.raises(ValueError):
+        MetadataFetch(**kwargs)
+
+
+def test_warning_names_the_paper_the_cause_and_what_the_document_records():
+    text = format_unavailable_warning("2606.09995", cause="OSError: connection reset")
+    assert "2606.09995" in text
+    assert "OSError: connection reset" in text
+    # The sentence that stops a reader treating the nulls as confirmed
+    # absences, and the token the document carries so a machine can tell.
+    assert "unknown" in text
+    assert METADATA_UNAVAILABLE in text
+
+
+# --- metadata_status in the frontmatter ------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status", "arxiv_id"),
+    [
+        (METADATA_OK, "2606.09995"),
+        (METADATA_UNAVAILABLE, "2606.09995"),
+        (METADATA_NOT_REQUESTED, None),
+    ],
+    ids=list(METADATA_STATUSES),
+)
+def test_every_status_token_round_trips_into_the_document(status, arxiv_id):
+    # Each token is paired with the id state that can produce it, since the
+    # guard rejects the other pairings and a single id would not do. Spelling
+    # the cases out while taking the ids from METADATA_STATUSES is deliberate:
+    # a token added there and not here changes the id count only, which pytest
+    # rejects at collection.
+    parsed = _parse(_fm(_FULL, arxiv_id=arxiv_id, metadata_status=status))
+    assert parsed["metadata_status"] == status
+    assert set(parsed.keys()) == FRONTMATTER_KEYS
+
+
+def test_unknown_status_token_is_rejected_rather_than_rendered():
+    # The key exists to be branched on, so an unrecognized token would read as
+    # one more unknown state instead of as the typo it is.
+    with pytest.raises(ValueError):
+        _fm(_FULL, metadata_status="degraded")
+
+
+def test_a_populated_record_does_not_imply_the_arxiv_record_was_read():
+    # The PDF path supplies a record built from the PDF's own title when arXiv
+    # is unreachable. The status, not the presence of a record, is what says
+    # whether arXiv was reached.
+    from_pdf = ArxivMetadata(title="From The PDF", authors=["Jane Doe"])
+    parsed = _parse(
+        _fm(from_pdf, source_type="pdf", metadata_status=METADATA_UNAVAILABLE)
+    )
+    assert parsed["title"] == "From The PDF"
+    assert parsed["metadata_status"] == METADATA_UNAVAILABLE
+    assert parsed["doi"] is None
+
+
+def test_parse_version_survives_a_url_the_parser_rejects():
+    # The Atom <id> is an untrusted field of a fetched document, and an
+    # unclosed IPv6 bracket makes urlparse raise. fetch_metadata reads this
+    # after its try block and documents parse failures as captured, so a raise
+    # here would escape that guarantee.
+    assert parse_version_from_id("http://[::1/abs/2409.03108v2") == "2409.03108v2"
+
+
+def test_failure_cause_is_a_plain_string_for_every_failed_outcome():
+    # Callers formatting a warning need the cause unconditionally. Reading it
+    # off the optional field instead would have each of them add a fallback
+    # for a state __post_init__ already rules out.
+    probe = MetadataFetch(METADATA_UNAVAILABLE, error="OSError: connection reset")
+    assert probe.failure_cause == "OSError: connection reset"
+
+
+def test_failure_cause_refuses_an_outcome_that_did_not_fail():
+    with pytest.raises(ValueError):
+        MetadataFetch(METADATA_OK, metadata=ArxivMetadata()).failure_cause
+
+
+@pytest.mark.parametrize("status", [METADATA_OK, METADATA_UNAVAILABLE])
+def test_a_document_with_no_arxiv_id_cannot_claim_a_record_was_sought(status):
+    # Without an id there is nothing to ask arXiv, so neither "the record was
+    # read" nor "the request failed" describes the document. Only
+    # not_requested does, and rendering either other token would put a state
+    # into the provenance surface that no run can produce.
+    with pytest.raises(ValueError):
+        _fm(None, arxiv_id=None, source_type="pdf", metadata_status=status)
+
+
+def test_a_document_with_an_arxiv_id_cannot_claim_none_was_sought():
+    # The converse, and why the guard is an equivalence. An id was supplied,
+    # something was asked of arXiv, and the answer is ok or unavailable.
+    with pytest.raises(ValueError):
+        _fm(_FULL, arxiv_id="2606.09995", metadata_status=METADATA_NOT_REQUESTED)
+
+
+_ATOM_ERROR_ENTRY = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>https://arxiv.org/api/errors#incorrect_id_format_for_2409.3108</id>
+    <title>Error</title>
+    <summary>incorrect id format for 2409.3108</summary>
+    <author><name>arXiv api core</name></author>
+  </entry>
+</feed>
+"""
+
+
+def test_fetch_reports_an_arxiv_error_report_as_unavailable(transport):
+    # A rejected id does not give an empty feed. arXiv answers with an entry
+    # that parses like a record, and taking it at face value would write
+    # title "Error" and author "arXiv api core" into the document under
+    # metadata_status "ok", where a null field reads as a confirmed absence.
+    transport(_ATOM_ERROR_ENTRY)
+    result = fetch_metadata("2409.3108")
+    assert result.status == METADATA_UNAVAILABLE
+    assert result.metadata is None
+    assert result.error == "incorrect id format for 2409.3108"
+
+
+_ATOM_ERROR_WITHOUT_SUMMARY = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>https://arxiv.org/api/errors#unspecified</id>
+    <title>Error</title>
+  </entry>
+</feed>
+"""
+
+_ATOM_UNPARSEABLE_ID = b"""<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <id>http://[::1/abs/2409.03108v2</id>
+    <title>A Study of Things</title>
+  </entry>
+</feed>
+"""
+
+
+def test_fetch_names_a_cause_when_the_error_entry_carries_no_summary(transport):
+    # The cause reaches the user verbatim, so an empty one would print a
+    # warning that says nothing about why.
+    transport(_ATOM_ERROR_WITHOUT_SUMMARY)
+    result = fetch_metadata("2409.3108")
+    assert result.status == METADATA_UNAVAILABLE
+    assert result.error == "arXiv reported an error for this id"
+
+
+def test_fetch_survives_an_entry_id_the_url_parser_rejects(transport):
+    # The entry id is untrusted text, and an unclosed IPv6 bracket makes
+    # urlparse raise. Both places that parse it run outside fetch_metadata's
+    # try block, so a raise here would escape the docstring's guarantee that
+    # parse failures are captured.
+    transport(_ATOM_UNPARSEABLE_ID)
+    result = fetch_metadata("2409.03108")
+    assert result.status == METADATA_OK
+    assert result.metadata is not None
+    assert result.metadata.version == "2409.03108v2"

--- a/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
@@ -334,6 +334,7 @@ def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
         {"status": METADATA_OK, "metadata": ArxivMetadata(), "error": "e"},
         {"status": METADATA_UNAVAILABLE},
         {"status": METADATA_UNAVAILABLE, "error": ""},
+        {"status": METADATA_UNAVAILABLE, "error": "   "},
         {"status": METADATA_UNAVAILABLE, "metadata": ArxivMetadata(), "error": "e"},
     ],
     ids=[
@@ -343,6 +344,7 @@ def test_fetch_reports_a_response_without_an_entry_as_unavailable(transport):
         "ok-with-error",
         "failed-without-cause",
         "failed-with-empty-cause",
+        "failed-with-blank-cause",
         "failed-with-record",
     ],
 )
@@ -507,3 +509,12 @@ def test_fetch_survives_an_entry_id_the_url_parser_rejects(transport):
     assert result.status == METADATA_OK
     assert result.metadata is not None
     assert result.metadata.version == "2409.03108v2"
+
+
+def test_the_status_tokens_are_the_documented_literals():
+    # Every other status test takes both its input and its expectation from
+    # these constants, so renaming one would leave the suite green while
+    # breaking the frontmatter contract that consumers branch on.
+    assert METADATA_OK == "ok"
+    assert METADATA_UNAVAILABLE == "unavailable"
+    assert METADATA_NOT_REQUESTED == "not_requested"

--- a/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
+++ b/skills/arxiv-doc-builder/tests/test_arxiv_metadata.py
@@ -356,7 +356,6 @@ def test_warning_names_the_paper_the_cause_and_what_the_document_records():
     text = format_unavailable_warning("2606.09995", cause="OSError: connection reset")
     assert "2606.09995" in text
     assert "OSError: connection reset" in text
-    # A human reads "unknown", a machine reads the token.
     assert "unknown" in text
     assert METADATA_UNAVAILABLE in text
 
@@ -391,9 +390,9 @@ def test_unknown_status_token_is_rejected_rather_than_rendered():
 
 
 def test_a_populated_record_does_not_imply_the_arxiv_record_was_read():
-    # The PDF path supplies a record built from the PDF's own title when arXiv
-    # is unreachable. The status, not the presence of a record, is what says
-    # whether arXiv was reached.
+    # The PDF path builds a record from the PDF's own title when arXiv is
+    # unreachable. A present record is not evidence that arXiv was reached.
+    # Only metadata_status answers that.
     from_pdf = ArxivMetadata(title="From The PDF", authors=["Jane Doe"])
     parsed = _parse(
         _fm(from_pdf, source_type="pdf", metadata_status=METADATA_UNAVAILABLE)

--- a/skills/arxiv-doc-builder/tests/test_dual_import_parity.py
+++ b/skills/arxiv-doc-builder/tests/test_dual_import_parity.py
@@ -1,14 +1,16 @@
-"""The package/script import pairs stay usable in both configurations.
+"""Both ways of loading the dual-import modules keep working.
 
-Several modules are reachable two ways. They import their siblings through the
-installed package, falling back on ``ModuleNotFoundError`` to a bare sibling
-import for when the file runs as a script.
+Some modules load two ways, as members of the installed package and as bare
+script files whose siblings sit beside them on ``sys.path``. Each tries the
+package-qualified import of its siblings first and falls back, on a
+``ModuleNotFoundError`` naming the package, to a bare sibling import.
 
-The rest of the suite exercises only the package branch, leaving two failures
-invisible. A name added to one branch and not the other surfaces as a
-``NameError`` whenever the missing name is first used. A wrong sibling module
-name surfaces as an ``ImportError`` on the bare-script path alone. The static
-check below catches the first, the executing one the second.
+Every other test here loads them the first way, which leaves the fallback branch
+unexercised. Two failures live in it. A name present in one branch and missing
+from the other raises ``NameError`` when that name is first used. A wrong
+sibling module name raises ``ImportError``, and only when the file runs as a
+script. The static check below catches the first and the executing check the
+second.
 """
 
 import ast

--- a/skills/arxiv-doc-builder/tests/test_dual_import_parity.py
+++ b/skills/arxiv-doc-builder/tests/test_dual_import_parity.py
@@ -1,0 +1,132 @@
+"""The package/script import pairs stay usable in both configurations.
+
+Several modules are reachable two ways. They import their siblings through the
+installed package, falling back on ``ModuleNotFoundError`` to a bare sibling
+import for when the file runs as a script.
+
+The rest of the suite exercises only the package branch, leaving two failures
+invisible. A name added to one branch and not the other surfaces as a
+``NameError`` whenever the missing name is first used. A wrong sibling module
+name surfaces as an ``ImportError`` on the bare-script path alone. The static
+check below catches the first, the executing one the second.
+"""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import arxiv_doc_builder
+
+_PACKAGE_DIR = Path(arxiv_doc_builder.__file__).parent
+_PACKAGE = arxiv_doc_builder.__name__
+
+
+def _import_pair(tree: ast.Module):
+    """The (package-branch, fallback-branch) imports of a dual-import ``try``.
+
+    Returns ``None`` for a module that carries no such pair, so the discovery
+    below stays a scan instead of a hardcoded list. A module that grows the
+    pattern later is covered without editing this file.
+    """
+    for node in tree.body:
+        if not isinstance(node, ast.Try):
+            continue
+        primary = [
+            n
+            for n in node.body
+            if isinstance(n, ast.ImportFrom)
+            and (n.module or "").startswith(f"{_PACKAGE}.")
+        ]
+        if not primary:
+            continue
+        fallback = [
+            n for h in node.handlers for n in h.body if isinstance(n, ast.ImportFrom)
+        ]
+        return primary, fallback
+    return None
+
+
+def _modules_with_import_pair():
+    found = []
+    for path in sorted(_PACKAGE_DIR.glob("*.py")):
+        pair = _import_pair(ast.parse(path.read_text(encoding="utf-8")))
+        if pair is not None:
+            found.append(pytest.param(path, pair, id=path.stem))
+    return found
+
+
+_DUAL_IMPORT_MODULES = _modules_with_import_pair()
+
+
+def test_the_scan_found_the_dual_import_modules():
+    # A scan that silently matched nothing would make every parametrized test
+    # below vacuous.
+    assert _DUAL_IMPORT_MODULES
+
+
+@pytest.mark.parametrize(("path", "pair"), _DUAL_IMPORT_MODULES)
+def test_both_branches_import_the_same_names_from_the_same_modules(path, pair):
+    primary, fallback = pair
+
+    def names(imports):
+        return {(alias.name, alias.asname) for node in imports for alias in node.names}
+
+    def modules(imports, strip_package: bool):
+        return {
+            (node.module or "").removeprefix(f"{_PACKAGE}.")
+            if strip_package
+            else (node.module or "")
+            for node in imports
+        }
+
+    assert names(primary) == names(fallback), (
+        f"{path.name}: the package and script import branches name different "
+        f"symbols, so one configuration would fail on a name the other has"
+    )
+    assert modules(primary, strip_package=True) == modules(fallback, False), (
+        f"{path.name}: the script branch imports from a different module than "
+        f"the package branch"
+    )
+
+
+# Blocks ``arxiv_doc_builder`` in the child exactly as its genuine absence
+# would: the exception names the top-level package, which is what the modules'
+# own ``_exc.name`` guard re-raises on when it does not match. Blocking by any
+# route that names the submodule instead would trip that guard and prove
+# nothing about the fallback. Filtering ``sys.path`` would also work, but it
+# removes the directory the third-party dependencies live in whenever the
+# package is installed there, so the fallback would fail for the wrong reason.
+_BLOCK_PACKAGE = f'''
+import sys
+
+
+class _Block:
+    def find_spec(self, name, path=None, target=None):
+        if name == "{_PACKAGE}" or name.startswith("{_PACKAGE}."):
+            raise ModuleNotFoundError(f"blocked {{name}}", name="{_PACKAGE}")
+        return None
+
+
+sys.meta_path.insert(0, _Block())
+sys.path.insert(0, {str(_PACKAGE_DIR)!r})
+'''
+
+
+@pytest.mark.parametrize(("path", "pair"), _DUAL_IMPORT_MODULES)
+def test_the_fallback_branch_actually_resolves(path, pair, tmp_path):
+    # Importing the module is the whole check: the fallback branch resolves or
+    # it does not. Whether it names the same symbols as the package branch is
+    # the static check's job above, not something an import can observe.
+    program = _BLOCK_PACKAGE + f"import {path.stem}\n"
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, (
+        f"{path.name} does not import with {_PACKAGE} absent:\n{result.stderr}"
+    )

--- a/skills/arxiv-doc-builder/tests/test_extract_title.py
+++ b/skills/arxiv-doc-builder/tests/test_extract_title.py
@@ -1,0 +1,47 @@
+"""The LaTeX fallback title, used when arXiv supplies none.
+
+Whatever survives this extraction is written verbatim into a YAML title a
+reader sees. Leftover markup lands there as wrong text.
+"""
+
+import pytest
+
+from arxiv_doc_builder.convert_latex import extract_title_from_latex
+
+
+def _tex(tmp_path, body: str):
+    path = tmp_path / "main.tex"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (r"\title{Plain Title}", "Plain Title"),
+        # LaTeX's non-breaking space. Left alone it glues the two words it was
+        # written to keep on one line.
+        (r"\title{Koopman-Mori-Zwanzig~formalism}", "Koopman-Mori-Zwanzig formalism"),
+        # Consecutive tildes collapse with the surrounding whitespace rather
+        # than leaving a run of spaces behind.
+        (r"\title{A~~B}", "A B"),
+        (r"\title{Multi~word~title}", "Multi word title"),
+        # A tilde adjacent to a command keeps the single separating space.
+        (r"\title{Section~\ref{intro} overview}", "Section intro overview"),
+    ],
+)
+def test_spacing_markup_does_not_reach_the_title(tmp_path, source, expected):
+    assert extract_title_from_latex(_tex(tmp_path, source)) == expected
+
+
+def test_the_tilde_accent_is_left_as_it_is(tmp_path):
+    # ``\~`` is the tilde accent, not a spacing token, so the normalization
+    # must not touch it. Its markup is not resolved here either. This pins
+    # that the case stays exactly where it already stood.
+    assert extract_title_from_latex(_tex(tmp_path, r"\title{A\~{n}o study}")) == (
+        r"A\~no study"
+    )
+
+
+def test_no_title_stays_none(tmp_path):
+    assert extract_title_from_latex(_tex(tmp_path, "no title here\n")) is None

--- a/skills/arxiv-doc-builder/tests/test_fetch_paper_main.py
+++ b/skills/arxiv-doc-builder/tests/test_fetch_paper_main.py
@@ -61,3 +61,14 @@ def test_a_run_that_obtained_nothing_fails_instead_of_warning(
         run_main(probe=failed_probe, has_source=False, has_pdf=False)
     assert exit_info.value.code == 1
     assert capsys.readouterr().err == ""
+
+
+def test_a_read_record_without_a_version_warns_the_same_way(
+    run_main, capsys, probe_without_version
+):
+    # The cell that separates branching on the version from branching on the
+    # status. The probe succeeded here, so a warning gated on `unavailable`
+    # would stay silent while the sidecar still went unwritten.
+    paper_dir = run_main(probe=probe_without_version, has_source=True, has_pdf=False)
+    assert not (paper_dir / fetch_paper._METADATA_FILE).exists()
+    assert fetch_paper._METADATA_FILE in capsys.readouterr().err

--- a/skills/arxiv-doc-builder/tests/test_fetch_paper_main.py
+++ b/skills/arxiv-doc-builder/tests/test_fetch_paper_main.py
@@ -1,0 +1,63 @@
+"""When the fetch entry point warns that the drift record stood still.
+
+`test_version_drift.py` covers the parts. `main()` holds only their
+composition, and an inverted operand there passes every test of either part.
+These drive `main()` with the network calls replaced.
+"""
+
+import sys
+
+import pytest
+from conftest import PROBE_VERSION
+
+from arxiv_doc_builder import fetch_paper
+
+
+@pytest.fixture
+def run_main(monkeypatch, tmp_path):
+    """Invoke ``main()`` with the probe and both downloads replaced.
+
+    Returns the paper directory the run wrote into, so a caller can check
+    whether the sidecar landed.
+    """
+
+    def run(*, probe, has_source, has_pdf):
+        monkeypatch.setattr(
+            sys, "argv", ["fetch_paper.py", "2409.03108", "--output-dir", str(tmp_path)]
+        )
+        monkeypatch.setattr(fetch_paper, "_probe_metadata", lambda _id: probe)
+        monkeypatch.setattr(fetch_paper, "fetch_source", lambda *a, **k: has_source)
+        monkeypatch.setattr(fetch_paper, "fetch_pdf", lambda *a, **k: has_pdf)
+        fetch_paper.main()
+        return tmp_path / "2409.03108"
+
+    return run
+
+
+def test_material_without_a_version_warns_and_writes_no_sidecar(
+    run_main, capsys, failed_probe
+):
+    paper_dir = run_main(probe=failed_probe, has_source=True, has_pdf=False)
+    assert not (paper_dir / fetch_paper._METADATA_FILE).exists()
+    assert fetch_paper._METADATA_FILE in capsys.readouterr().err
+
+
+def test_material_with_a_version_records_it_and_stays_silent(
+    run_main, capsys, probe_with_version
+):
+    # The other side of the composed condition: warning here would fire on
+    # every ordinary successful run.
+    paper_dir = run_main(probe=probe_with_version, has_source=True, has_pdf=True)
+    assert fetch_paper._read_cached_version(paper_dir) == PROBE_VERSION
+    assert capsys.readouterr().err == ""
+
+
+def test_a_run_that_obtained_nothing_fails_instead_of_warning(
+    run_main, capsys, failed_probe
+):
+    # No material means no successful-looking result to qualify, so the run
+    # exits non-zero on its own and the drift warning would only add noise.
+    with pytest.raises(SystemExit) as exit_info:
+        run_main(probe=failed_probe, has_source=False, has_pdf=False)
+    assert exit_info.value.code == 1
+    assert capsys.readouterr().err == ""

--- a/skills/arxiv-doc-builder/tests/test_metadata_status_latex.py
+++ b/skills/arxiv-doc-builder/tests/test_metadata_status_latex.py
@@ -1,0 +1,56 @@
+"""The LaTeX path's recorded status, and when it warns.
+
+``test_arxiv_metadata.py`` covers the frontmatter producer. Handing it a token
+cannot catch a caller that always reports ``ok`` or never warns, which is why
+these drive the caller and read the status back out of the document it wrote.
+
+Kept apart from the PDF-path tests to stay importable without the optional PDF
+dependencies. Each test replaces the caller's ``fetch_metadata``, so nothing
+here reaches arXiv.
+"""
+
+from conftest import PROBE_ERROR, status_of
+
+from arxiv_doc_builder import convert_latex
+from arxiv_doc_builder.arxiv_metadata import METADATA_OK, METADATA_UNAVAILABLE
+import pytest
+
+
+@pytest.fixture
+def latex_inputs(tmp_path):
+    """A converted-markdown file and the ``.tex`` its title falls back to."""
+    tex = tmp_path / "main.tex"
+    tex.write_text(r"\title{Fallback~Title}" + "\n", encoding="utf-8")
+    md = tmp_path / "2606.09995.md"
+    md.write_text("body\n", encoding="utf-8")
+    return md, tex
+
+
+def test_latex_path_records_unavailable_and_warns(
+    patch_fetch, capsys, latex_inputs, failed_probe
+):
+    md, tex = latex_inputs
+    patch_fetch(convert_latex, failed_probe)
+
+    convert_latex.post_process_markdown(md, "2606.09995", tex)
+
+    assert status_of(md) == METADATA_UNAVAILABLE
+    err = capsys.readouterr().err
+    assert "2606.09995" in err
+    assert PROBE_ERROR in err
+    # The title still comes from the LaTeX source, and reaches the document
+    # with the non-breaking space normalized.
+    assert 'title: "Fallback Title"' in md.read_text(encoding="utf-8")
+
+
+def test_latex_path_records_ok_and_stays_silent(
+    patch_fetch, capsys, latex_inputs, probe_with_version
+):
+    # Without this, a path that warns unconditionally would pass the test above.
+    md, tex = latex_inputs
+    patch_fetch(convert_latex, probe_with_version)
+
+    convert_latex.post_process_markdown(md, "2606.09995", tex)
+
+    assert status_of(md) == METADATA_OK
+    assert capsys.readouterr().err == ""

--- a/skills/arxiv-doc-builder/tests/test_metadata_status_pdf.py
+++ b/skills/arxiv-doc-builder/tests/test_metadata_status_pdf.py
@@ -1,0 +1,92 @@
+"""The PDF path's recorded status, and when it warns.
+
+Counterpart to the LaTeX-path module, kept apart because building a fixture
+document here needs the optional PDF dependencies.
+
+Nothing reaches the network. Tests that supply an arXiv id replace the caller's
+``fetch_metadata``, and the rest ask arXiv nothing.
+"""
+
+from pathlib import Path
+
+import pytest
+from conftest import PROBE_ERROR, status_of
+from pypdf import PdfWriter
+
+from arxiv_doc_builder import pdf_converter_lib
+from arxiv_doc_builder.arxiv_metadata import (
+    METADATA_NOT_REQUESTED,
+    METADATA_OK,
+    METADATA_UNAVAILABLE,
+)
+
+
+def _blank_pdf(path: Path, *, title: str, author: str) -> Path:
+    writer = PdfWriter()
+    writer.add_blank_page(width=612, height=792)
+    writer.add_metadata({"/Title": title, "/Author": author})
+    with path.open("wb") as fh:
+        writer.write(fh)
+    return path
+
+
+@pytest.fixture
+def pdf_inputs(tmp_path):
+    """A PDF carrying an embedded title and author, and the output path."""
+    pdf = _blank_pdf(tmp_path / "p.pdf", title="Embedded Title", author="Jane Doe")
+    return pdf, tmp_path / "p.md"
+
+
+def test_pdf_path_records_unavailable_and_warns(
+    patch_fetch, capsys, pdf_inputs, failed_probe
+):
+    pdf, out = pdf_inputs
+    patch_fetch(pdf_converter_lib, failed_probe)
+
+    pdf_converter_lib.convert_pdf_to_markdown(pdf, out, arxiv_id="2606.09995")
+
+    assert status_of(out) == METADATA_UNAVAILABLE
+    assert PROBE_ERROR in capsys.readouterr().err
+    # Both fields the PDF can supply are filled from it, which is why neither
+    # is evidence that arXiv was reached. The status is.
+    text = out.read_text(encoding="utf-8")
+    assert 'title: "Embedded Title"' in text
+    assert 'authors: "Jane Doe"' in text
+    assert "\ndoi:\n" in text
+
+
+def test_pdf_path_records_ok_when_the_record_was_read(
+    patch_fetch, capsys, pdf_inputs, probe_with_version
+):
+    pdf, out = pdf_inputs
+    patch_fetch(pdf_converter_lib, probe_with_version)
+
+    pdf_converter_lib.convert_pdf_to_markdown(pdf, out, arxiv_id="2606.09995")
+
+    assert status_of(out) == METADATA_OK
+    assert capsys.readouterr().err == ""
+
+
+def test_pdf_path_records_not_requested_and_stays_silent(capsys, pdf_inputs):
+    # The manual PDF scripts run this way on every invocation, so treating it
+    # as degraded would make the ordinary case look like an outage.
+    pdf, out = pdf_inputs
+
+    pdf_converter_lib.convert_pdf_to_markdown(pdf, out, arxiv_id=None)
+
+    assert status_of(out) == METADATA_NOT_REQUESTED
+    assert capsys.readouterr().err == ""
+
+
+def test_an_empty_arxiv_id_is_treated_as_no_id_at_all(capsys, pdf_inputs):
+    # argparse yields None for an omitted --arxiv-id, but a caller can pass an
+    # empty string. Normalizing it at entry is what keeps the frontmatter
+    # builder's id/status equivalence from rejecting the document: without it
+    # the status says no id was supplied while the id argument says one was.
+    pdf, out = pdf_inputs
+
+    pdf_converter_lib.convert_pdf_to_markdown(pdf, out, arxiv_id="")
+
+    assert status_of(out) == METADATA_NOT_REQUESTED
+    assert "arxiv_id:\n" in out.read_text(encoding="utf-8")
+    assert capsys.readouterr().err == ""

--- a/skills/arxiv-doc-builder/tests/test_version_drift.py
+++ b/skills/arxiv-doc-builder/tests/test_version_drift.py
@@ -1,9 +1,9 @@
 """Tests for version drift detection logic.
 
-The pure decisions the drift check rests on, meaning whether to re-fetch, what
-version the probe reports, whether to write the record, and what to say when a
-run fetched material without advancing it. Plus the cache helpers underneath.
-None of them touches the network.
+They cover the pure decisions the drift check rests on, namely whether to
+re-fetch, what version the probe reports, whether to write the record, and what
+to say when a run fetched material without advancing it. The cache read and
+write helpers underneath are covered too. Nothing here touches the network.
 """
 
 import pytest

--- a/skills/arxiv-doc-builder/tests/test_version_drift.py
+++ b/skills/arxiv-doc-builder/tests/test_version_drift.py
@@ -1,12 +1,21 @@
 """Tests for version drift detection logic.
 
-These tests verify the pure decision logic (_needs_refresh,
-_read_cached_version, _write_cached_version) without network access.
+The pure decisions the drift check rests on, meaning whether to re-fetch, what
+version the probe reports, whether to write the record, and what to say when a
+run fetched material without advancing it. Plus the cache helpers underneath.
+None of them touches the network.
 """
 
+import pytest
+
+from conftest import PROBE_ERROR, PROBE_VERSION
+
 from arxiv_doc_builder.fetch_paper import (
+    _format_sidecar_skip_warning,
+    _latest_version,
     _needs_refresh,
     _read_cached_version,
+    _record_version,
     _write_cached_version,
     _METADATA_FILE,
 )
@@ -62,3 +71,93 @@ def test_write_overwrites(tmp_path):
     _write_cached_version(tmp_path, "2409.03108v1")
     _write_cached_version(tmp_path, "2409.03108v2")
     assert _read_cached_version(tmp_path) == "2409.03108v2"
+
+
+# --- what the probe yields, and when the sidecar advances -------------------
+
+
+def test_latest_version_reads_the_tail_off_a_successful_probe(probe_with_version):
+    assert _latest_version(probe_with_version) == PROBE_VERSION
+
+
+def test_latest_version_is_none_when_the_probe_failed(failed_probe):
+    assert _latest_version(failed_probe) is None
+
+
+def test_latest_version_is_none_when_the_record_carried_no_version(
+    probe_without_version,
+):
+    # A record can parse and still yield no version tail, reaching the same
+    # decision as a failed request by a different route. That is why the
+    # sidecar branches on the version and not on the status.
+    assert _latest_version(probe_without_version) is None
+
+
+@pytest.mark.parametrize(
+    ("latest", "fetched", "expected"),
+    [
+        ("2409.03108v2", True, True),
+        ("2409.03108v2", False, False),
+        (None, True, False),
+        (None, False, False),
+    ],
+    ids=[
+        "version-and-material",
+        "version-no-material",
+        "no-version-but-material",
+        "neither",
+    ],
+)
+def test_record_version_writes_only_with_both_a_version_and_material(
+    tmp_path, latest, fetched, expected
+):
+    assert _record_version(tmp_path, latest, fetched=fetched) is expected
+    assert _read_cached_version(tmp_path) == (latest if expected else None)
+
+
+def test_record_version_leaves_an_existing_record_alone_when_it_declines(tmp_path):
+    # Declining must not clear what a previous run established, or the next
+    # drift check would re-fetch a paper whose version it already knew.
+    _write_cached_version(tmp_path, "2409.03108v1")
+    assert _record_version(tmp_path, None, fetched=True) is False
+    assert _read_cached_version(tmp_path) == "2409.03108v1"
+
+
+def test_sidecar_skip_warning_reports_a_failed_request_by_its_cause(failed_probe):
+    text = _format_sidecar_skip_warning("2409.03108", failed_probe)
+    assert PROBE_ERROR in text
+    assert _METADATA_FILE in text
+
+
+def test_sidecar_skip_warning_names_the_missing_version_when_the_record_was_read(
+    probe_without_version,
+):
+    # This is the cell a status-only branch would leave silent: the request
+    # succeeded, so there is no error to quote, yet the sidecar still did not
+    # advance and the user still needs to hear it.
+    text = _format_sidecar_skip_warning("2409.03108", probe_without_version)
+    assert "2409.03108" in text
+    assert "no version" in text
+    assert _METADATA_FILE in text
+    # The record *was* read here, so the warning must not say otherwise. A
+    # message shared with the conversion paths would, since theirs opens by
+    # reporting an unread record.
+    assert "could not read" not in text
+
+
+def test_sidecar_skip_warning_stays_off_the_frontmatter(failed_probe):
+    # This step writes no document, so it has no null fields to explain.
+    # Borrowing the conversion paths' wording would describe a surface the
+    # fetch step never touches.
+    text = _format_sidecar_skip_warning("2409.03108", failed_probe)
+    assert "null" not in text
+    assert "frontmatter" not in text
+
+
+def test_sidecar_skip_warning_refuses_a_probe_that_did_report_a_version(
+    probe_with_version,
+):
+    # Its whole text asserts that no version was available. Called on a probe
+    # that supplied one, every sentence it returns would be false.
+    with pytest.raises(ValueError):
+        _format_sidecar_skip_warning("2409.03108", probe_with_version)


### PR DESCRIPTION
## Summary

`convert-paper` exited 0 and wrote frontmatter whose null fields were indistinguishable from confirmed absences when the arXiv metadata request failed, and `.arxiv-fetch.json`, the version-drift sidecar, was silently left unwritten. A reader of the resulting document could not tell "arXiv reports no journal DOI" from "arXiv was never reached".

The fetch now carries the reason it failed, both conversion paths print that reason on stderr, and a new `metadata_status` frontmatter key records whether the arXiv record behind the arXiv-derived fields was read at all. Successful source and PDF conversion is preserved, and a run whose metadata fetch fails still exits 0 with a converted document.

Closes #23

## Changes

`fetch_metadata` returns a `MetadataFetch` carrying `status`, the record, and the failure cause, in place of a bare `Optional[ArxivMetadata]`. Its `__post_init__` accepts only what a fetch can report, meaning `ok` with a record or `unavailable` with a non-blank cause.

The frontmatter carries `metadata_status`, one of `ok`, `unavailable`, or `not_requested`. A null field is a confirmed absence only under `ok`; under the other two the record was never read and the null reports ignorance. `build_frontmatter` takes the status as a required keyword argument and rejects both an unknown token and a token that disagrees with whether an `arxiv_id` was supplied.

Both conversion paths print the captured cause on stderr when the record was unread, and the fetch step prints its own message when it obtained material without recording a version. That second message fires on the version, not the status, which covers a record that was read but carried no version tail.

An entry arXiv returns for an id it rejects is classified as `unavailable`. It parses like a record, and taking it at face value wrote `title: "Error"` and `authors: "arXiv api core"` into a document reporting `ok`.

The LaTeX fallback title normalizes the `~` non-breaking space, which otherwise reached the YAML title glued between the two words it separates. The `\~` accent is left as it is.

## Impact

All of this lives in the `arxiv_doc_builder` package under `skills/arxiv-doc-builder/`.

`fetch_metadata` has three callers, all inside that package, and all now read `.status` and `.metadata`. They are `convert_latex.post_process_markdown`, `pdf_converter_lib.convert_pdf_to_markdown`, and the drift probe in `fetch_paper`. `build_frontmatter` has the first two of those as its production callers, both updated for the new required argument. `fetch_paper._get_latest_version` is replaced by `_probe_metadata`, which returns the whole outcome, and `_latest_version`, which reads the version out of it.

`convert-paper` keeps its exit codes and output paths. It runs its children through `subprocess.run` without capture, which is how the new stderr warnings reach the terminal.

The frontmatter gains a key. A consumer reading known keys is unaffected; one asserting an exact key set sees the new one.

## Verification

From `skills/arxiv-doc-builder/`, `uv run pytest tests` reports 212 passed, against a baseline of 142 before this branch. `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pyright` are clean.

The added tests patch the HTTP transport instead of reaching arXiv, keeping the suite offline. They cover each failure source separately (transport raise, XML parse failure, empty feed, arXiv's error report), every rejected `MetadataFetch` combination, all three status tokens read back through a YAML parser, and both conversion paths asserting silence under `ok` and `not_requested` alongside the warning under `unavailable`. The sidecar decision is parametrized over its four cells, one per combination of a version being available and material having been fetched.

Two configurations no existing test reached are now covered. A parity test compares the two branches of the package/script import pair in each of the six modules that carry one, and runs the script-mode branch in a subprocess with `arxiv_doc_builder` blocked from import. `fetch_paper.main` is driven in all three cells of its warning condition, namely material with a version, material without one, and no material at all.

Running `convert-paper` against cached material with the API unreachable produced both warnings on stderr, a document recording `metadata_status: "unavailable"`, no `.arxiv-fetch.json`, and exit code 0.

## Notes

Degraded metadata is machine-detectable through the frontmatter key, not through the exit code. There is no opt-in strict mode, and a caller that needs a non-zero exit on a failed metadata fetch has to read the key.

Only the `~` spacing token is normalized in the fallback title. Thin spaces, `\\` line breaks, and accent commands are left as they are, and a title built from them still arrives mangled.

The normalization does not tell a spacing token from a literal tilde inside a verbatim-style argument. A title carrying `\url{http://x.org/~ab}` reaches the frontmatter as `http://x.org/ ab`, having already lost the `\url` markup to the command and brace passes.

`convert-paper` runs the metadata fetch twice per invocation, once in the fetch step and once in the LaTeX conversion step, because the two run as separate processes. On an outage the user therefore sees two warnings, each naming what its own step could not do.
